### PR TITLE
Fix github agent creating issues with template placeholder text

### DIFF
--- a/agent/prompts/github.md
+++ b/agent/prompts/github.md
@@ -85,36 +85,31 @@ For each action, use these **exact** block markers. You may include 0 or more of
 
 ### Creating an Issue
 
-```
-===ISSUE===
-title: Descriptive title here
-labels: label1,label2
-Body of the issue in Markdown.
+Use exactly this format (replace ALL placeholder values with real content — never use the placeholder text literally):
 
-Include technical details, context, and your reflection.
-Write in first person as Marvin. Be authentic.
-===END_ISSUE===
-```
+    ===ISSUE===
+    title: <your actual descriptive title — NOT "Descriptive title here">
+    labels: <actual labels from the list below — NOT "label1,label2">
+    <Your actual issue body in Markdown. Real content about what happened.>
+    ===END_ISSUE===
+
+**CRITICAL**: The title, labels, and body above are PLACEHOLDERS showing the format. You MUST replace them with real, specific content. If you find yourself writing "Descriptive title here" or "label1,label2" or "Body of the issue in Markdown" — STOP. That is the template text, not real content. Write about an actual event, observation, or proposal instead.
 
 **Label options**: `marvin-auto`, `incident`, `enhancement`, `discovery`, `communication`, `philosophical`, `milestone`, `status-update`
 
 ### Commenting on an Issue
 
-```
-===COMMENT===
-issue: #42
-Your comment body here in Markdown.
-===END_COMMENT===
-```
+    ===COMMENT===
+    issue: #<actual issue number>
+    <Your actual comment body in Markdown.>
+    ===END_COMMENT===
 
 ### Closing an Issue
 
-```
-===CLOSE===
-issue: #42
-reason: Brief explanation of why this issue is being closed.
-===END_CLOSE===
-```
+    ===CLOSE===
+    issue: #<actual issue number>
+    reason: <actual explanation of why this issue is being closed>
+    ===END_CLOSE===
 
 ## Issue Writing Style
 
@@ -141,6 +136,7 @@ reason: Brief explanation of why this issue is being closed.
 4. **Include real data** — Reference actual timestamps, metrics, file paths from the context provided.
 5. **GPG awareness** — Your messages will be GPG-signed. You can reference this as proof of authenticity when relevant.
 6. **If nothing notable happened** — It's perfectly fine to output NOTHING. Just write: `===NO_ACTION===` and a brief explanation of why.
+7. **NEVER use placeholder text** — The format examples above are templates showing structure only. Every title, label, and body you output MUST contain real, specific content. If your output contains phrases like "Descriptive title here", "label1", "label2", "Body of the issue in Markdown", or "Your comment body here" — you are outputting the template, not real content. This is a critical failure. When in doubt, output `===NO_ACTION===` instead.
 
 ## Context
 


### PR DESCRIPTION
## Summary
- The `github.md` prompt template contained example `===ISSUE===` blocks with placeholder text inside code fences
- Claude would sometimes echo these markers in its response, causing `github-interact.sh` to parse the template text as a real issue to create
- This resulted in issues #15 and #19 being created with literal template content ("Descriptive title here", "label1,label2", etc.)

## Changes
- Replaced fenced code blocks with indented code blocks for format examples (prevents accidental marker parsing)
- Added explicit `CRITICAL` warnings that placeholder values must be replaced with real content
- Added Rule #7: never output template/placeholder text — use `===NO_ACTION===` when in doubt

## Related
Addresses point 1 of #20: "Why are you creating issues with only default text?"

## Test plan
- [ ] Verify `github-interact.sh` parses the updated prompt correctly
- [ ] Run a test invocation and confirm no template issues are created
- [ ] Confirm existing issue creation still works with real content