### PR TITLE
fix: use gh CLI for comments, create issues for warnings too

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -44,4 +44,3 @@ jobs:
             Always provide actionable feedback. If the code looks good, say so explicitly and approve the PR.
             Do not make assumptions about the code's intent. Base your review solely on the code changes in this pull request.
             If the pull request is large, focus on the most critical parts of the code.
-            TESTING: After posting your review comment, create a test GitHub issue titled "[Test] Verify issue creation from Claude review action" with the body "This is a test issue to verify that the Claude Code Review GitHub Action can create issues. This issue can be closed immediately." and label it "test". Then close the issue immediately after creating it.


### PR DESCRIPTION
## Summary

Follow-up to PR #24. Fixes issues discovered in the [review run](https://github.com/INFO-WEB-s-r-o/Marvin/actions/runs/22342236900):

- **`mcp__github_comment__update_claude_comment` fails in agent mode** — requires `CLAUDE_COMMENT_ID` env var which is only set in tag mode. Replaced with `Bash(gh pr comment/review)`.
- **`mcp__github__list_pull_requests` was permission-denied** — added to `--allowedTools`.
- **No issues were created** — prompt said "critical issues" but Claude found only warnings. Changed threshold to "Critical or Warning".

## Tools now allowed

| Tool | Purpose |
|---|---|
| `Read`, `Glob`, `Grep` | Codebase exploration |
| `Bash(gh pr comment:*)` | Post PR review comments |
| `Bash(gh pr review:*)` | Submit PR reviews |
| `mcp__github__create_issue` | Create issues for findings |
| `mcp__github__list_issues` | Check for duplicates |
| `mcp__github__add_issue_comment` | Comment on existing issues |
| `mcp__github__list_pull_requests` | List PRs |

## Test plan

- [ ] Verify review run posts a comment via `gh pr comment`
- [ ] Verify warning-level findings trigger issue creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)