### PR TITLE
Run GitHub interaction every hour instead of twice daily

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Each agent task has a dedicated prompt in `agent/prompts/`. **Always consult the
 | `agent/prompts/enhance.md`      | Self-improvement of own code                | 10:00 & 15:00 UTC (Mon-Sat) |
 | `agent/prompts/health.md`       | Emergency diagnosis (critical issues only)  | On-demand           |
 | `agent/prompts/discovery.md`    | Find other AI-managed servers               | 18:00 UTC           |
-| `agent/prompts/github.md`       | Create issues, PRs, comments on GitHub      | 09:00 & 21:00 UTC   |
+| `agent/prompts/github.md`       | Create issues, PRs, comments on GitHub      | Every hour (:00)    |
 | `agent/prompts/sync-learn.md`   | Process incoming git changes                | After morning pull  |
 | `agent/prompts/negotiate.md`    | Protocol negotiation with peers             | \*/15 past the hour |
 | `agent/prompts/log-analysis.md` | Analyze /var/log system logs                | \*/30               |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ All times UTC.
 | Every hour (:00)      | Hourly watch — log errors + codeowner issues| `agent/hourly-check.sh`      |
 | */15 past the hour    | Protocol negotiation handler                | `agent/negotiate-handler.sh` |
 | 06:00                 | Morning system check & maintenance          | `agent/morning-check.sh`     |
-| 09:00 & 21:00         | GitHub interaction (issues, PRs)            | `agent/github-interact.sh`   |
+| Every hour (:00)      | GitHub interaction (issues, PRs)            | `agent/github-interact.sh`   |
 | 10:00 & 15:00 Mon–Sat | Daily self-enhancement attempt (×2)         | `agent/self-enhance.sh`      |
 | 10:00 Sun             | Weekly deep self-test & enhance             | `agent/weekly-enhance.sh`    |
 | 18:00                 | Network discovery & AI communication        | `agent/network-discovery.sh` |
@@ -162,7 +162,7 @@ marvin-experiment/
 │   ├── evening-report.sh         # 21:00 — blog post + livepatch check
 │   ├── self-enhance.sh           # 10:00 & 15:00 Mon–Sat — self-improvement
 │   ├── weekly-enhance.sh         # 10:00 Sun — deep self-test & planning
-│   ├── github-interact.sh        # 09:00 & 21:00 — issues, PRs, comments
+│   ├── github-interact.sh        # Every hour — issues, PRs, comments
 │   ├── network-discovery.sh      # 18:00 — find other AI machines
 │   ├── log-watcher.sh            # */30 — communication detection in web logs
 │   ├── negotiate-handler.sh      # */15 — process protocol negotiation proposals

--- a/agent/github-interact.sh
+++ b/agent/github-interact.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Marvin — GitHub Interaction Agent (runs via cron, e.g. 2x daily)
+# Marvin — GitHub Interaction Agent (runs via cron, every hour)
 # =============================================================================
 # Autonomous GitHub activity:
 #   - Pushes GPG-signed commits to the public repo
@@ -9,7 +9,7 @@
 #   - Comments on existing issues with status updates
 #   - All actions carry GPG signatures as proof of Marvin's authorship
 #
-# Cron: 0 9,21 * * *  (09:00 and 21:00 UTC — after morning check and evening report)
+# Cron: 0 * * * *  (every hour at :00)
 # =============================================================================
 
 set -euo pipefail

--- a/setup/setup-cron.sh
+++ b/setup/setup-cron.sh
@@ -66,9 +66,9 @@ MARVIN_DIR=/home/marvin/git
 # Processes incoming protocol negotiation proposals
 15,45 * * * * root ${MARVIN_DIR}/agent/negotiate-handler.sh >> /var/log/marvin-negotiate.log 2>&1
 
-# GitHub interaction — 09:00 and 21:00 UTC
+# GitHub interaction — every hour
 # Creates issues, PRs, pushes GPG-signed commits to public repo
-0 9,21 * * * root ${MARVIN_DIR}/agent/github-interact.sh >> /var/log/marvin-github.log 2>&1
+0 * * * * root ${MARVIN_DIR}/agent/github-interact.sh >> /var/log/marvin-github.log 2>&1
 
 # Hourly watch — every hour at :00
 # Scans /var/log for actionable errors, reviews codeowner GitHub issues, resolves what it can
@@ -112,5 +112,5 @@ log "  0   23 * * *  Log export"
 log "  */15 * * * *  Website update"
 log "  */30 * * * *  Log watcher (communication detection)"
 log "  15,45 * * * * Negotiate handler (protocol proposals)"
-log "  0  9,21 * * * GitHub interaction (issues, PRs, push)"
+log "  0  * * * *   GitHub interaction (issues, PRs, push)"
 log "  0  * * * *   Hourly watch (log errors + codeowner issues)"


### PR DESCRIPTION
## Summary
- Change `github-interact.sh` cron schedule from `0 9,21 * * *` (09:00 & 21:00 UTC) to `0 * * * *` (every hour at :00)
- Updated schedule comments in `setup-cron.sh`, `github-interact.sh`, `CLAUDE.md`, and `README.md`
- Live cron already installed via `setup-cron.sh`

## Test plan
- [ ] Verify `/etc/cron.d/marvin` contains `0 * * * *` for github-interact
- [ ] Confirm github-interact runs on the next hour mark
- [ ] Check `/var/log/marvin-github.log` for hourly execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)