### PR TITLE
fix: resolve merge conflict in health-monitor.sh + ps false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - `agent/disk-cleanup.sh` — automated disk hygiene: removes old compressed logs (>30d), apt cache, stale run logs (>14d), old metrics (>90d), temp files, and vacuums systemd journal to 7 days
-- Runaway process monitoring in `health-monitor.sh` — tracks processes exceeding 50% CPU across health check intervals, auto-kills after 10 minutes sustained; excludes known-good processes (claude, apt, node)
+- Runaway process monitoring in `health-monitor.sh` — tracks processes exceeding 50% CPU across health check intervals, auto-kills after 10 minutes sustained; excludes known-good processes (claude, apt, node, ps)
+- Merge conflict marker detection in `agent/self-test.sh` — scans all agent scripts for leftover `<<<<<<<` / `=======` / `>>>>>>>` markers that would break bash parsing
+- Verified unattended-upgrades configured with security-only policy (was already in place)
 
 ### Fixed
 
+- **CRITICAL**: `health-monitor.sh` had unresolved merge conflict markers on `main` branch (lines 79-94), breaking the script entirely. Resolved by keeping the PID reuse guard from `main`.
+- `health-monitor.sh`: added `ps` to known-good process exclusion list — the `ps` command itself was triggering false positive "High CPU process detected" warnings every 5 minutes
 - `log-export.sh`: added EXIT trap to always return git to `main` branch, preventing repo from being stranded on `data/*` branches after failures
 - `common.sh`: `run_claude` now pipes prompt via stdin instead of shell argument, fixing "Argument list too long" error that broke log-analysis agent with large prompts
 - `health-monitor.sh`: empty `ISSUES` array no longer produces `[""]` in `data/status.json`; correctly outputs `[]` when healthy

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -49,7 +49,7 @@
 - [ ] Verify all cron jobs execute without errors for 48h straight
 - [ ] Implement automatic swap management (create/resize if RAM pressure detected)
 - [x] Add disk cleanup automation (remove old logs, temp files, apt cache)
-- [ ] Set up unattended-upgrades with security-only policy
+- [x] Set up unattended-upgrades with security-only policy
 - [x] Create a self-test that validates all agent scripts parse without syntax errors
 - [ ] Implement graceful restart for nginx without downtime
 - [x] Add process watchdog — restart critical services if they die
@@ -256,6 +256,10 @@
 - [x] **[2026-02-24]** Process watchdog (service restart) — _health-monitor.sh already restarts nginx, fail2ban, cron if down. Now confirmed and documented._
 - [x] **[2026-02-24]** Fail2ban nginx jails — _nginx-http-auth and nginx-botsearch jails already active alongside sshd. Marked as complete._
 - [x] **[2026-02-24]** log-export.sh trap-based branch cleanup — _Added EXIT trap to always return to main branch, preventing the repo from being stuck on data/* branches after failures._
+- [x] **[2026-02-24]** Fix merge conflict in health-monitor.sh — _Resolved <<<<<<< conflict markers on main branch that broke PID reuse guard. Kept full PID reuse detection logic._
+- [x] **[2026-02-24]** Add `ps` to runaway process exclusion list — _The `ps` command itself was appearing at 100% CPU during the sort operation, causing false positive warnings every 5 minutes._
+- [x] **[2026-02-24]** Merge conflict detector in self-test.sh — _New test checks all agent scripts for leftover <<<<<<< / ======= / >>>>>>> markers to catch broken merges before they cause runtime failures._
+- [x] **[2026-02-24]** Unattended-upgrades verified — _Already configured with security-only policy, daily package list updates, auto-removal of unused deps, no automatic reboot. Marked as complete._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -69,17 +69,13 @@ while IFS= read -r line; do
     proc_cpu=$(echo "$line" | awk '{print $2}')
     proc_name=$(echo "$line" | awk '{print $3}')
 
-    # Skip known-good processes (Claude, apt, dpkg)
+    # Skip known-good processes (Claude, apt, dpkg, ps itself)
     case "$proc_name" in
-        claude|apt*|dpkg|npm|node) continue ;;
+        claude|apt*|dpkg|npm|node|ps) continue ;;
     esac
 
     # Check if this PID was already flagged
     prev_ts=$(jq -r --arg pid "$proc_pid" '.[$pid].first_seen // 0' "$RUNAWAY_FILE" 2>/dev/null || echo 0)
-<<<<<<< enhance/2026-02-24-stability-hardening
-    now_ts=$(date +%s)
-
-=======
     tracked_name=$(jq -r --arg pid "$proc_pid" '.[$pid].name // ""' "$RUNAWAY_FILE" 2>/dev/null || echo "")
     now_ts=$(date +%s)
 
@@ -91,7 +87,6 @@ while IFS= read -r line; do
         prev_ts=0
     fi
 
->>>>>>> main
     if [[ "$prev_ts" -eq 0 ]]; then
         # First sighting — record it
         jq --arg pid "$proc_pid" --arg name "$proc_name" --argjson ts "$now_ts" --arg cpu "$proc_cpu" \

--- a/agent/self-test.sh
+++ b/agent/self-test.sh
@@ -47,6 +47,19 @@ while IFS= read -r script; do
     fi
 done < <(find "${MARVIN_DIR}/agent" -name "*.sh" -type f | sort)
 
+# ─── 1b. Merge conflict marker check ─────────────────────────────────────────
+# Detects leftover <<<<<<< / ======= / >>>>>>> markers that break scripts
+
+marvin_log "INFO" "Self-test: checking for merge conflict markers"
+
+while IFS= read -r script; do
+    if grep -qE '^<{7} |^={7}$|^>{7} ' "$script" 2>/dev/null; then
+        test_fail "merge conflict markers: $(basename "$script")"
+    else
+        test_pass "no conflict markers: $(basename "$script")"
+    fi
+done < <(find "${MARVIN_DIR}/agent" -name "*.sh" -type f | sort)
+
 # ─── 2. JSON data file validation ────────────────────────────────────────────
 
 marvin_log "INFO" "Self-test: validating JSON data files"


### PR DESCRIPTION
## Summary

- **CRITICAL FIX**: `health-monitor.sh` had unresolved merge conflict markers (`<<<<<<< enhance/...` / `=======` / `>>>>>>> main`) on the `main` branch, breaking the script entirely since it could not be parsed by bash
- **False positive fix**: Added `ps` to the known-good process exclusion list — the `ps` command itself was appearing at 100% CPU during `--sort=%cpu` execution, generating false "High CPU process detected" warnings every 5 minutes
- **Prevention**: Added merge conflict marker detector to `self-test.sh` — scans all agent scripts for leftover `<<<<<<<` / `=======` / `>>>>>>>` markers to catch this class of bug automatically
- **Documentation**: Marked `unattended-upgrades` as complete (already configured with security-only policy)

## Files Changed

| File | Change |
|------|--------|
| `agent/health-monitor.sh` | Resolved merge conflict, added `ps` to exclusion list |
| `agent/self-test.sh` | Added merge conflict marker detection test |
| `CHANGELOG.md` | Updated with fixes |
| `POSSIBLE_ENHANCEMENTS.md` | Marked completed items, added to log |

## Test Plan

- [x] All 17 agent scripts pass `bash -n` syntax check
- [x] No merge conflict markers found in any file
- [x] `grep -rE '^<{7}|^={7}$|^>{7}' agent/` returns nothing

## Risk Assessment

**Low risk.** The merge conflict resolution keeps the more complete code (PID reuse guard). The `ps` exclusion prevents noise without reducing real detection capability. The self-test addition is purely additive.

🤖 Generated by Marvin (autonomous self-enhancement session)