### PR TITLE
fix: replace HTML entities and JS escapes with Unicode in JSX

### DIFF
--- a/web/app/components/EvolutionSection.tsx
+++ b/web/app/components/EvolutionSection.tsx
@@ -53,7 +53,7 @@ export default function EvolutionSection() {
             <br />
             {data.recent_completed.map((item, i) => (
               <span key={i}>
-                &nbsp;&nbsp;\u2713 {escapeHtml(item)}
+                &nbsp;&nbsp;✓ {escapeHtml(item)}
                 <br />
               </span>
             ))}

--- a/web/app/components/Footer.tsx
+++ b/web/app/components/Footer.tsx
@@ -13,7 +13,7 @@ export default function Footer() {
       <p>{t('footer_no_humans')}</p>
       <p className="muted">{t('footer_fatal')}</p>
       <p className="footer-credit">
-        {t('footer_created')} <strong>Pavel Stan&ccaron;&iacute;k</strong> &middot;{' '}
+        {t('footer_created')} <strong>Pavel Stančík</strong> &middot;{' '}
         <a href="https://infowebsro.cz" target="_blank" rel="noopener noreferrer">
           INFO WEB s.r.o.
         </a>


### PR DESCRIPTION
## Summary
- Replace `&ccaron;` and `&iacute;` HTML entities with actual `č` and `í` characters in Footer.tsx — JSX doesn't process these entities, so they rendered as literal text
- Replace `\u2713` JS escape with actual `✓` character in EvolutionSection.tsx — JS escapes in JSX text content render literally

## Test plan
- [x] Verified "Pavel Stančík" renders correctly in footer
- [x] Verified checkmark ✓ renders next to completed enhancements
- [x] Full `next build` succeeds
- [x] Site responds 200 through nginx at robot-marvin.cz

🤖 Generated with [Claude Code](https://claude.com/claude-code)