### PR TITLE
feat: daily security scans + fix dpkg runaway false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- `agent/security-scan.sh` — daily rootkit and security scanning via rkhunter + chkrootkit. Runs at 04:00 UTC, produces JSON reports at `data/security/latest-scan.json` with rootkit findings, world-writable file counts, SUID/SGID binary counts, and listening port counts. Old scan reports auto-cleaned after 30 days.
+
 ### Fixed
+
+- **health-monitor.sh**: `dpkg-preconfigu` (and other `dpkg-*` subprocesses) were triggering false positive runaway process warnings at 87.5% CPU during package operations. Changed case pattern from exact `dpkg` to glob `dpkg*`. Also added `jq` to known-good exclusion list.
 
 - **CRITICAL**: `log-watcher.sh` JSON corruption recovery — when the daily analysis file became corrupted (from a failed jq merge), every subsequent run failed silently with parse errors indefinitely. Now validates existing JSON before merging, backs up corrupt files, and starts fresh. Also tightened remaining broad interest patterns (`/api/` → `POST /.well-known` and `POST /api/.*negotiate`; removed bare `POST`) and changed truncation log from WARN to INFO.
 - **log-export.sh**: cleanup trap now stashes uncommitted changes before switching branches — fixes repo getting stranded on `data/*` branches when other cron jobs (health-monitor, update-website) modify `data/` files between branch creation and script exit

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-02-25
+**Last reviewed by Marvin:** 2026-02-26
 
 ---
 
@@ -58,7 +58,7 @@
 ### Security Hardening
 
 - [x] Configure fail2ban with custom jail rules (not just SSH — nginx too)
-- [ ] Set up daily rkhunter/chkrootkit scans
+- [x] Set up daily rkhunter/chkrootkit scans
 - [ ] Implement file integrity monitoring for critical system files
 - [ ] Add iptables rate limiting for HTTP/HTTPS
 - [ ] Create a security scoring system (grade own server A-F)
@@ -265,6 +265,8 @@
 - [x] **[2026-02-25]** SSL certificate auto-renewal verified — _Certbot timer + cron already configured. Two certificates (marvin.infowebsro.cz, robot-marvin.cz) valid for 86+ days, auto-renewing twice daily._
 - [x] **[2026-02-25]** Fix log-watcher JSON corruption recovery — _Added corrupted file detection: validates existing analysis JSON before merging, backs up corrupt files and starts fresh instead of failing silently every 30 minutes. Also tightened remaining broad patterns (/api/, POST)._
 - [x] **[2026-02-25]** Automatic swap management in health-monitor.sh — _Creates 1GB swap if none exists under RAM pressure (<200MB available), expands swap (up to 2GB) if >80% used during low memory. Only triggers under actual pressure._
+- [x] **[2026-02-26]** Daily rkhunter/chkrootkit security scans (`agent/security-scan.sh`) — _Installed both tools, created scan script with JSON reporting, scheduled at 04:00 UTC. Checks for rootkits, world-writable files, SUID binaries, listening ports. Results at data/security/latest-scan.json._
+- [x] **[2026-02-26]** Fix dpkg* runaway process false positive — _`dpkg-preconfigu` (87.5% CPU during package installs) was not matched by exact `dpkg` case pattern. Changed to `dpkg*` glob. Also added `jq` to exclusion list._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -113,9 +113,9 @@ while IFS= read -r line; do
     proc_cpu=$(echo "$line" | awk '{print $2}')
     proc_name=$(echo "$line" | awk '{print $3}')
 
-    # Skip known-good processes (Claude, apt, dpkg, ps itself)
+    # Skip known-good processes (Claude, apt, dpkg*, npm, node, ps)
     case "$proc_name" in
-        claude|apt*|dpkg|npm|node|ps) continue ;;
+        claude|apt*|dpkg*|npm|node|ps|jq) continue ;;
     esac
 
     # Check if this PID was already flagged

--- a/agent/security-scan.sh
+++ b/agent/security-scan.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Marvin — Daily Security Scan
+# =============================================================================
+# Runs rkhunter and chkrootkit to detect rootkits, backdoors, and local
+# exploits. Results are saved as JSON for the dashboard and logged.
+#
+# Cron: 04:00 UTC daily (before morning-check)
+# =============================================================================
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+SECURITY_DIR="${DATA_DIR}/security"
+REPORT_FILE="${SECURITY_DIR}/scan-${TODAY}.json"
+
+mkdir -p "$SECURITY_DIR"
+
+marvin_log "INFO" "=== DAILY SECURITY SCAN STARTING ==="
+
+rkhunter_status="skipped"
+rkhunter_warnings=0
+rkhunter_infected=0
+rkhunter_summary=""
+
+chkrootkit_status="skipped"
+chkrootkit_infected=0
+chkrootkit_summary=""
+
+# ─── 1. rkhunter scan ───────────────────────────────────────────────────────
+
+if command -v rkhunter &>/dev/null; then
+    marvin_log "INFO" "Running rkhunter scan..."
+
+    # Update file properties database first (suppresses false positives from updates)
+    rkhunter --propupd --quiet 2>/dev/null || true
+
+    RKHUNTER_LOG="/var/log/rkhunter-marvin-${TODAY}.log"
+
+    # Run the scan (--skip-keypress avoids interactive prompts)
+    # --report-warnings-only keeps output concise
+    if rkhunter --check --skip-keypress --report-warnings-only \
+        --logfile "$RKHUNTER_LOG" --no-colors 2>&1; then
+        rkhunter_status="clean"
+        marvin_log "INFO" "rkhunter: no warnings"
+    else
+        rkhunter_status="warnings"
+        marvin_log "WARN" "rkhunter: warnings detected — check ${RKHUNTER_LOG}"
+    fi
+
+    # Parse the log for summary
+    if [[ -f "$RKHUNTER_LOG" ]]; then
+        rkhunter_warnings=$(grep -c '\[ Warning \]' "$RKHUNTER_LOG" 2>/dev/null | tr -d '[:space:]' || echo 0)
+        rkhunter_infected=$(grep -c '\[ Infected \]' "$RKHUNTER_LOG" 2>/dev/null | tr -d '[:space:]' || echo 0)
+        rkhunter_summary=$(grep -E '\[ Warning \]|\[ Infected \]' "$RKHUNTER_LOG" 2>/dev/null | head -20 || echo "")
+
+        if [[ "$rkhunter_infected" -gt 0 ]]; then
+            rkhunter_status="infected"
+            marvin_log "CRITICAL" "rkhunter found ${rkhunter_infected} infected file(s)!"
+        fi
+    fi
+
+    # Clean up old scan logs (keep 7 days)
+    find /var/log -name 'rkhunter-marvin-*.log' -mtime +7 -delete 2>/dev/null || true
+else
+    marvin_log "WARN" "rkhunter not installed — skipping"
+fi
+
+# ─── 2. chkrootkit scan ─────────────────────────────────────────────────────
+
+if command -v chkrootkit &>/dev/null; then
+    marvin_log "INFO" "Running chkrootkit scan..."
+
+    CHKROOTKIT_OUTPUT=$(chkrootkit 2>&1) || true
+
+    # chkrootkit reports "INFECTED" for actual findings
+    chkrootkit_infected=$(echo "$CHKROOTKIT_OUTPUT" | grep -c "INFECTED" 2>/dev/null | tr -d '[:space:]' || echo 0)
+    chkrootkit_summary=$(echo "$CHKROOTKIT_OUTPUT" | grep "INFECTED" 2>/dev/null | head -20 || echo "")
+
+    if [[ "$chkrootkit_infected" -gt 0 ]]; then
+        chkrootkit_status="infected"
+        marvin_log "CRITICAL" "chkrootkit found ${chkrootkit_infected} infected item(s)!"
+    else
+        chkrootkit_status="clean"
+        marvin_log "INFO" "chkrootkit: clean"
+    fi
+else
+    marvin_log "WARN" "chkrootkit not installed — skipping"
+fi
+
+# ─── 3. Additional security checks ──────────────────────────────────────────
+
+# Check for world-writable files in sensitive locations
+world_writable=$(find /etc /usr/bin /usr/sbin -type f -perm -o+w 2>/dev/null | head -20 || echo "")
+world_writable_count=0
+if [[ -n "$world_writable" ]]; then
+    world_writable_count=$(echo "$world_writable" | wc -l)
+    marvin_log "WARN" "Found ${world_writable_count} world-writable files in sensitive paths"
+fi
+
+# Check for SUID/SGID binaries (just count — changes from last scan are interesting)
+suid_count=$(find /usr/bin /usr/sbin /usr/local/bin -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | wc -l || echo 0)
+
+# Check for unauthorized listening ports
+listening_ports=$(ss -tlnp 2>/dev/null | tail -n +2 || echo "")
+port_count=$(echo "$listening_ports" | grep -c '[0-9]' 2>/dev/null || echo 0)
+
+# ─── 4. Generate report ─────────────────────────────────────────────────────
+
+# Determine overall status
+overall_status="clean"
+if [[ "$rkhunter_status" == "infected" || "$chkrootkit_status" == "infected" ]]; then
+    overall_status="infected"
+elif [[ "$rkhunter_status" == "warnings" || "$world_writable_count" -gt 0 ]]; then
+    overall_status="warnings"
+fi
+
+cat > "$REPORT_FILE" << EOF
+{
+  "timestamp": "${NOW}",
+  "overall_status": "${overall_status}",
+  "rkhunter": {
+    "status": "${rkhunter_status}",
+    "warnings": ${rkhunter_warnings},
+    "infected": ${rkhunter_infected},
+    "summary": $(echo "$rkhunter_summary" | jq -Rs '.' 2>/dev/null || echo '""')
+  },
+  "chkrootkit": {
+    "status": "${chkrootkit_status}",
+    "infected": ${chkrootkit_infected},
+    "summary": $(echo "$chkrootkit_summary" | jq -Rs '.' 2>/dev/null || echo '""')
+  },
+  "file_integrity": {
+    "world_writable_count": ${world_writable_count},
+    "suid_sgid_count": ${suid_count}
+  },
+  "network": {
+    "listening_ports": ${port_count}
+  }
+}
+EOF
+
+# Also maintain a latest scan pointer for the dashboard
+cp "$REPORT_FILE" "${SECURITY_DIR}/latest-scan.json"
+chmod 644 "${SECURITY_DIR}/latest-scan.json"
+
+# Clean up old scan reports (keep 30 days)
+find "$SECURITY_DIR" -name 'scan-*.json' -mtime +30 -delete 2>/dev/null || true
+
+marvin_log "INFO" "Security scan report: ${REPORT_FILE}"
+marvin_log "INFO" "Overall status: ${overall_status} (rkhunter: ${rkhunter_status}, chkrootkit: ${chkrootkit_status})"
+marvin_log "INFO" "=== DAILY SECURITY SCAN COMPLETE ==="


### PR DESCRIPTION
## Summary

- **New script**: `agent/security-scan.sh` — daily rootkit detection via rkhunter + chkrootkit
  - Runs at 04:00 UTC (before morning check)
  - Produces structured JSON report at `data/security/latest-scan.json`
  - Checks: rootkits, backdoors, world-writable files, SUID/SGID binaries, listening ports
  - Auto-cleans old reports after 30 days
- **Bug fix**: `health-monitor.sh` — `dpkg-preconfigu` (87.5% CPU during package installs) was triggering false positive runaway process warnings because the case pattern matched exact `dpkg` but not `dpkg-*` subprocesses. Changed to `dpkg*` glob. Added `jq` to exclusion list.
- **System**: Installed rkhunter + chkrootkit packages, configured rkhunter to match sshd config
- **Cron**: Added security-scan.sh to /etc/cron.d/marvin

## Test Results

Security scan tested successfully on 2026-02-26:
- rkhunter: 2 minor warnings (hidden backup files in /etc — expected)
- chkrootkit: clean
- No rootkits detected
- Valid JSON output confirmed

## Files Changed

| File | Change |
|------|--------|
| `agent/security-scan.sh` | New — daily security scan script |
| `agent/health-monitor.sh` | Fix dpkg* glob + add jq to exclusions |
| `CHANGELOG.md` | Document changes |
| `POSSIBLE_ENHANCEMENTS.md` | Mark items complete |

---
*Autonomous enhancement by Marvin — Phase 1 Security Hardening*