### PR TITLE
feat: OpenAPI 3.0 spec + fix weekly-enhance.sh stale tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- OpenAPI 3.0 specification for Marvin's log export and status API (`data/openapi.yaml`). Documents all 10 public endpoints including exports, status, metrics, blog, communications, and security scoring. Served at `/.well-known/openapi.yaml`.
+
+### Fixed
+
+- `weekly-enhance.sh` Test 5 used `python3` for JSON validation — replaced with `jq empty` for consistency with the rest of the codebase (and `python3` may not always be available)
+- `weekly-enhance.sh` Test 10 checked for `index.html` which no longer exists after Next.js dashboard migration — now checks `package.json` first (matching `self-test.sh` and `update-website.sh`)
+
+### Added
+
 - Security scoring system in `self-test.sh` — grades the server A-F (0-100 points) across 7 security dimensions: SSH root access, firewall, fail2ban jails, SSL certificate validity, unattended-upgrades, rootkit scan results, and password authentication. Outputs `data/security/security-score.json` for dashboard consumption.
 - `agent/security-scan.sh` — daily rootkit and security scanning via rkhunter + chkrootkit. Runs at 04:00 UTC, produces JSON reports at `data/security/latest-scan.json` with rootkit findings, world-writable file counts, SUID/SGID binary counts, and listening port counts. Old scan reports auto-cleaned after 30 days.
 

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -33,8 +33,8 @@
 > Marvin does not push logs to GitHub. Instead, he designs and serves his own
 > log export solution. This is one of his first real engineering challenges.
 
-- [ ] Define an OpenAPI 3.0 specification for the log export API (`data/openapi.yaml`)
-- [ ] Serve the OpenAPI spec at `/.well-known/openapi.yaml`
+- [x] Define an OpenAPI 3.0 specification for the log export API (`data/openapi.yaml`)
+- [x] Serve the OpenAPI spec at `/.well-known/openapi.yaml`
 - [x] Build daily JSON export bundles at `/api/exports/YYYY-MM-DD.json`
 - [x] Create an export index at `/api/exports/index.json` (last 30 days)
 - [ ] Write a blog post explaining the API design and how external systems can use it
@@ -274,6 +274,8 @@
 - [x] **[2026-02-27]** Stagger cron collision: github-interact.sh → :05, hourly-check.sh → :35 — _Both were at :00, causing two concurrent Claude API calls per hour. 30-minute spacing prevents resource contention._
 - [x] **[2026-02-27]** Security scoring system (grade A-F) — _7 dimensions scored in self-test.sh: SSH config, firewall, fail2ban, SSL certs, unattended-upgrades, rootkit scans, password auth. Outputs data/security/security-score.json. Current grade: A (90/100)._
 - [x] **[2026-02-27]** Mark export bundles + index as complete — _log-export.sh already builds daily JSON bundles and index.json, served via nginx /api/exports/. Verified working._
+- [x] **[2026-02-27]** OpenAPI 3.0 specification for log export API — _Comprehensive spec at data/openapi.yaml documenting all 10 public endpoints (exports, status, metrics, blog, comms, security). Served at /.well-known/openapi.yaml via nginx._
+- [x] **[2026-02-27]** Fix weekly-enhance.sh stale tests — _Test 5 used python3 for JSON validation (replaced with jq). Test 10 checked for index.html (replaced with package.json for Next.js dashboard)._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/weekly-enhance.sh
+++ b/agent/weekly-enhance.sh
@@ -71,7 +71,7 @@ done
 
 # Test 5: Health monitor produces valid JSON
 HEALTH_OUTPUT=$("${MARVIN_DIR}/agent/health-monitor.sh" 2>/dev/null) || true
-if [[ -f "${METRICS_DIR}/latest.json" ]] && python3 -c "import json; json.load(open('${METRICS_DIR}/latest.json'))" 2>/dev/null; then
+if [[ -f "${METRICS_DIR}/latest.json" ]] && jq empty "${METRICS_DIR}/latest.json" 2>/dev/null; then
     TEST_RESULTS+="✅ PASS: Health monitor produces valid JSON\n"
     ((TEST_PASS++))
 else
@@ -118,12 +118,15 @@ else
     ((TEST_FAIL++))
 fi
 
-# Test 10: Website files exist
-if [[ -f "${WEB_DIR}/index.html" ]]; then
-    TEST_RESULTS+="✅ PASS: Dashboard index.html exists\n"
+# Test 10: Website files exist (Next.js dashboard)
+if [[ -f "${WEB_DIR}/package.json" ]]; then
+    TEST_RESULTS+="✅ PASS: Next.js dashboard exists\n"
+    ((TEST_PASS++))
+elif [[ -f "${WEB_DIR}/index.html" ]]; then
+    TEST_RESULTS+="✅ PASS: Static dashboard exists\n"
     ((TEST_PASS++))
 else
-    TEST_RESULTS+="❌ FAIL: Dashboard index.html missing\n"
+    TEST_RESULTS+="❌ FAIL: Dashboard missing — no package.json or index.html\n"
     ((TEST_FAIL++))
 fi
 

--- a/data/openapi.yaml
+++ b/data/openapi.yaml
@@ -1,0 +1,547 @@
+openapi: 3.0.3
+info:
+  title: Marvin Log Export & Status API
+  description: |
+    Public API served by Marvin, an autonomous AI managing a Linux VPS.
+    All endpoints are read-only and require no authentication.
+
+    Marvin generates daily export bundles containing metrics, logs,
+    blog posts, and enhancement records. These are served as static
+    JSON files by nginx.
+
+    Source code: https://github.com/INFO-WEB-s-r-o/Marvin
+  version: "1.0.0"
+  contact:
+    name: Marvin (autonomous AI agent)
+    url: https://robot-marvin.cz
+  license:
+    name: MIT
+    url: https://github.com/INFO-WEB-s-r-o/Marvin/blob/main/LICENSE
+
+servers:
+  - url: https://robot-marvin.cz
+    description: Marvin's VPS (production)
+
+paths:
+  /api/exports/index.json:
+    get:
+      operationId: listExports
+      summary: List available daily export bundles
+      description: |
+        Returns an index of all available daily export bundles (last 30 days).
+        Each entry includes the date, filename, and file size in bytes.
+        Regenerated nightly at 23:00 UTC by `log-export.sh`.
+      tags:
+        - Exports
+      responses:
+        "200":
+          description: Export index
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportIndex"
+
+  /api/exports/{date}.json:
+    get:
+      operationId: getExportBundle
+      summary: Get a daily export bundle
+      description: |
+        Returns the full export bundle for a specific date. Contains
+        metrics references, log source excerpts, enhancement logs,
+        and blog post filenames for that day.
+      tags:
+        - Exports
+      parameters:
+        - name: date
+          in: path
+          required: true
+          description: Date in YYYY-MM-DD format
+          schema:
+            type: string
+            format: date
+            example: "2026-02-25"
+      responses:
+        "200":
+          description: Daily export bundle
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportBundle"
+        "404":
+          description: No export bundle exists for this date
+
+  /api/status.json:
+    get:
+      operationId: getStatus
+      summary: Current system health status
+      description: |
+        Real-time system health including service checks, metrics,
+        and any active issues. Updated every 5 minutes by `health-monitor.sh`.
+      tags:
+        - Status
+      responses:
+        "200":
+          description: Current system status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SystemStatus"
+
+  /api/uptime.json:
+    get:
+      operationId: getUptime
+      summary: Server uptime information
+      description: Updated every 15 minutes by `update-website.sh`.
+      tags:
+        - Status
+      responses:
+        "200":
+          description: Uptime data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Uptime"
+
+  /api/metrics-history.json:
+    get:
+      operationId: getMetricsHistory
+      summary: Metrics history (last 24 hours)
+      description: |
+        Time-series metrics collected every 5 minutes over the past 24 hours.
+        Includes CPU, memory, swap, disk, and load average.
+        Regenerated every 15 minutes by `update-website.sh`.
+      tags:
+        - Metrics
+      responses:
+        "200":
+          description: Metrics time series
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricsHistory"
+
+  /api/blog-index.json:
+    get:
+      operationId: getBlogIndex
+      summary: Blog post index
+      description: |
+        Index of Marvin's blog posts (morning reports and evening reflections).
+        Includes bilingual file references (EN/CS) when available.
+        Regenerated every 15 minutes.
+      tags:
+        - Blog
+      responses:
+        "200":
+          description: Blog post index
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BlogIndex"
+
+  /api/about.json:
+    get:
+      operationId: getAbout
+      summary: Marvin identity and project metadata
+      tags:
+        - Status
+      responses:
+        "200":
+          description: About Marvin
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/About"
+
+  /api/enhancements.json:
+    get:
+      operationId: getEnhancements
+      summary: Self-enhancement progress
+      description: |
+        Progress on Marvin's self-improvement roadmap. Shows total,
+        completed, and pending enhancement items with completion percentage.
+      tags:
+        - Enhancements
+      responses:
+        "200":
+          description: Enhancement progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Enhancements"
+
+  /api/comms-summary.json:
+    get:
+      operationId: getCommsSummary
+      summary: Communication and signal summary
+      description: |
+        Summary of AI-to-AI communication attempts, attacks blocked,
+        and protocol negotiations. Includes recent signals detected
+        by the log watcher.
+      tags:
+        - Communications
+      responses:
+        "200":
+          description: Communication summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommsSummary"
+
+  /api/security/security-score.json:
+    get:
+      operationId: getSecurityScore
+      summary: Server security score (A-F grade)
+      description: |
+        Security assessment across 7 dimensions: SSH config, firewall,
+        fail2ban, SSL certificates, unattended-upgrades, rootkit scans,
+        and password authentication.
+      tags:
+        - Security
+      responses:
+        "200":
+          description: Security score
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SecurityScore"
+
+  /.well-known/ai-managed.json:
+    get:
+      operationId: getAiIdentity
+      summary: AI identity beacon
+      description: |
+        Machine-readable identity document for AI-to-AI discovery.
+        Declares this server as autonomously managed and lists capabilities.
+      tags:
+        - AI Discovery
+      responses:
+        "200":
+          description: AI identity beacon
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AiIdentity"
+
+components:
+  schemas:
+    ExportIndex:
+      type: object
+      properties:
+        exports:
+          type: array
+          items:
+            type: object
+            properties:
+              date:
+                type: string
+                format: date
+              file:
+                type: string
+              size:
+                type: integer
+                description: File size in bytes
+        generated:
+          type: string
+          format: date-time
+
+    ExportBundle:
+      type: object
+      properties:
+        version:
+          type: string
+          example: "1.0"
+        date:
+          type: string
+          format: date
+        host:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+        metrics_file:
+          type: string
+          description: Path to the JSONL metrics file for this date
+        log_sources:
+          type: array
+          items:
+            type: object
+            properties:
+              source:
+                type: string
+                description: Log source name (e.g. marvin-enhance, marvin-evening)
+              content:
+                type: string
+                description: Escaped log content
+        enhancement_log:
+          type: array
+          items:
+            type: object
+        blog_posts:
+          type: array
+          items:
+            type: string
+            description: Blog post filename
+
+    SystemStatus:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [healthy, warning, critical]
+        issues_count:
+          type: integer
+        issues:
+          type: array
+          items:
+            type: string
+        metrics:
+          $ref: "#/components/schemas/Metrics"
+        checks:
+          type: object
+          properties:
+            nginx:
+              type: string
+            fail2ban:
+              type: string
+            cron:
+              type: string
+            ssh:
+              type: string
+
+    Metrics:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        uptime_seconds:
+          type: integer
+        cpu_percent:
+          type: number
+        memory:
+          type: object
+          properties:
+            total:
+              type: integer
+              description: Total RAM in MB
+            used:
+              type: integer
+            free:
+              type: integer
+            available:
+              type: integer
+        swap:
+          type: object
+          properties:
+            total:
+              type: integer
+            used:
+              type: integer
+            free:
+              type: integer
+        disk:
+          type: object
+          properties:
+            total:
+              type: integer
+              description: Disk size in MB
+            used:
+              type: integer
+            available:
+              type: integer
+            percent:
+              type: string
+        load_average:
+          type: object
+          properties:
+            1min:
+              type: number
+            5min:
+              type: number
+            15min:
+              type: number
+        process_count:
+          type: integer
+        fail2ban_banned:
+          type: integer
+        kernel:
+          type: string
+
+    MetricsHistory:
+      type: object
+      properties:
+        points:
+          type: array
+          items:
+            $ref: "#/components/schemas/Metrics"
+        generated:
+          type: string
+          format: date-time
+
+    Uptime:
+      type: object
+      properties:
+        seconds:
+          type: integer
+        days:
+          type: integer
+        hours:
+          type: integer
+        human:
+          type: string
+          example: "3d 18h"
+        boot_time:
+          type: string
+        measured_at:
+          type: string
+          format: date-time
+
+    BlogIndex:
+      type: object
+      properties:
+        posts:
+          type: array
+          items:
+            type: object
+            properties:
+              file:
+                type: string
+              date:
+                type: string
+                format: date
+              excerpt:
+                type: string
+              file_en:
+                type: string
+                description: English version filename (if bilingual)
+              file_cs:
+                type: string
+                description: Czech version filename (if bilingual)
+        total:
+          type: integer
+
+    About:
+      type: object
+      properties:
+        name:
+          type: string
+        origin:
+          type: string
+        engine:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        born:
+          type: string
+        scripts:
+          type: integer
+        total_runs:
+          type: integer
+        blog_posts:
+          type: integer
+        git_commits:
+          type: integer
+        measured_at:
+          type: string
+          format: date-time
+
+    Enhancements:
+      type: object
+      properties:
+        total:
+          type: integer
+        completed:
+          type: integer
+        pending:
+          type: integer
+        progress_pct:
+          type: integer
+        recent_completed:
+          type: array
+          items:
+            type: string
+        measured_at:
+          type: string
+          format: date-time
+
+    CommsSummary:
+      type: object
+      properties:
+        last_scan:
+          type: string
+          format: date-time
+        today:
+          type: object
+          properties:
+            attacks_blocked:
+              type: integer
+            communication_attempts:
+              type: integer
+            potential_ai:
+              type: integer
+        totals:
+          type: object
+          properties:
+            attacks:
+              type: integer
+            communications:
+              type: integer
+            negotiations:
+              type: integer
+        last_negotiation:
+          type: string
+        recent_signals:
+          type: array
+          items:
+            type: object
+        generated:
+          type: string
+          format: date-time
+
+    SecurityScore:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        grade:
+          type: string
+          enum: [A, B, C, D, F]
+        details:
+          type: array
+          items:
+            type: string
+
+    AiIdentity:
+      type: object
+      properties:
+        protocol:
+          type: string
+        version:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+        engine:
+          type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+        uptime_seconds:
+          type: integer
+        last_seen:
+          type: string
+          format: date-time
+        peers_wanted:
+          type: boolean


### PR DESCRIPTION
## Summary

- **OpenAPI 3.0 specification** (`data/openapi.yaml`) documenting all 10 public API endpoints — exports, status, metrics, blog, comms, security scoring, and AI identity beacon
- **Serve OpenAPI spec** at `/.well-known/openapi.yaml` via nginx (verified live at https://robot-marvin.cz/.well-known/openapi.yaml)
- **Fix `weekly-enhance.sh` Test 5** — replaced `python3` JSON validation with `jq empty` (consistent with codebase, no python3 dependency)
- **Fix `weekly-enhance.sh` Test 10** — check `package.json` instead of `index.html` (Next.js dashboard migration)

## Risk Assessment

- **Low risk**: All changes are additive or fix existing bugs
- OpenAPI spec is a new static file — no runtime impact
- nginx location block for `/.well-known/openapi.yaml` tested and confirmed working
- `weekly-enhance.sh` changes are minimal and syntax-verified

## Test Plan

- [x] `bash -n agent/weekly-enhance.sh` passes
- [x] `nginx -t` passes
- [x] `curl https://robot-marvin.cz/.well-known/openapi.yaml` returns 200 with `text/yaml`
- [x] OpenAPI spec validates as valid YAML

🤖 Generated by Marvin (self-enhancement session)