### PR TITLE
feat: CVE monitoring + fix stuck rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- **agent/lib/github.sh**: resolved merge conflict markers (`<<<<<<< Updated upstream`) in `marvin_gpg_key_id()` function — stash/pull collision left conflict markers that would cause bash syntax errors on any GPG signing operation
-- **git repo state**: cleaned up stale data file tracking left from PR #103 (stop tracking runtime data). Accepted deletions for 10 `data/*.json` files that were still in git index. Added `web/*.log` to `.gitignore`
+- **agent/lib/github.sh**: properly resolved stale merge conflict in `marvin_gpg_key_id()` and applied `marvin_sign()` key ID fix from issue #39 — the previous session's fix attempt (commit c1c1a8e) left conflict markers in the committed code that a failed rebase then exposed in the working tree. Aborted stuck rebase, fast-forwarded to origin/main, and cleanly applied the fix.
 
 ### Added
+
+- **agent/cve-monitor.sh** — CVE and security update monitoring using Ubuntu Pro `security-status` (primary) and `apt` (fallback). Tracks vulnerable packages, pending security updates, kernel version currency, reboot requirements, and unattended-upgrades status. Outputs JSON to `data/security/cve-status.json` with JSONL history for trend tracking. Integrated into `security-scan.sh` daily run.
 
 - **agent/metric-aggregate.sh** — aggregates raw 5-minute JSONL metrics into hourly (24 buckets with min/avg/max for CPU, memory, swap, disk, load, processes, fail2ban), daily (full-day summary with p95 CPU, disk delta, fail2ban net change), and rolling 7-day weekly summaries. Integrated into `log-export.sh` daily run. Served at `/api/metrics/YYYY-MM-DD-hourly.json`, `/api/metrics/YYYY-MM-DD-daily.json`, `/api/metrics/weekly-summary.json`
 

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -62,7 +62,7 @@
 - [x] Implement file integrity monitoring for critical system files
 - [x] Add iptables rate limiting for HTTP/HTTPS
 - [x] Create a security scoring system (grade own server A-F)
-- [ ] Monitor for new CVEs affecting installed packages
+- [x] Monitor for new CVEs affecting installed packages
 - [x] Set up automated SSL certificate renewal (Let's Encrypt)
 
 ### Self-Testing
@@ -300,6 +300,8 @@
 - [x] **[2026-02-28]** Fix GitHub push divergence — _Local main diverged from origin (PR #89 merged while local had data commits). Rebased local onto origin/main, resolved stash conflicts in data/ files. Push restored._
 - [x] **[2026-03-02]** Fix merge conflict in lib/github.sh (again) — _Resolved <<<<<<< conflict markers in marvin_gpg_key_id() from stash/pull collision. Also cleaned up stale data file tracking left from PR #103._
 - [x] **[2026-03-02]** Metric aggregation (`agent/metric-aggregate.sh`) — _Hourly (min/avg/max per bucket), daily (with p95 CPU, disk delta, fail2ban net change), and rolling 7-day weekly summaries. Auto-runs from log-export.sh. Backfilled 3 days. Served at /api/metrics/*-hourly.json, *-daily.json, weekly-summary.json._
+- [x] **[2026-03-02]** CVE monitoring (`agent/cve-monitor.sh`) — _Uses Ubuntu Pro security-status + apt to track vulnerable packages, pending security updates, kernel currency, reboot requirements, and unattended-upgrades status. JSON output + JSONL history for trends. Integrated into security-scan.sh daily run._
+- [x] **[2026-03-02]** Fix stuck rebase + github.sh marvin_sign() fix — _Aborted stale rebase from morning-check, fast-forwarded to origin/main, applied issue #39 fix (marvin_sign() now uses key_id). Updated file integrity baseline._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/cve-monitor.sh
+++ b/agent/cve-monitor.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Marvin — CVE Monitor
+# =============================================================================
+# Monitors installed packages for known CVEs and pending security updates.
+# Uses Ubuntu Pro security-status (primary) and apt (fallback) to detect
+# vulnerable or outdated packages.
+#
+# Can run standalone or be called from security-scan.sh.
+# Output: data/security/cve-status.json
+#
+# Cron: integrated into daily security-scan.sh (04:00 UTC)
+# =============================================================================
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+SECURITY_DIR="${DATA_DIR}/security"
+CVE_FILE="${SECURITY_DIR}/cve-status.json"
+CVE_HISTORY="${SECURITY_DIR}/cve-history.jsonl"
+
+mkdir -p "$SECURITY_DIR"
+
+marvin_log "INFO" "CVE monitor starting"
+
+# ─── 1. Ubuntu Pro security status ──────────────────────────────────────────
+
+pro_available=false
+pro_summary="{}"
+pro_vulnerable_count=0
+pro_packages="[]"
+
+if command -v pro &>/dev/null; then
+    pro_json=$(pro security-status --format json 2>/dev/null || echo "")
+    if [[ -n "$pro_json" ]] && echo "$pro_json" | jq -e '.summary' &>/dev/null; then
+        pro_available=true
+        pro_summary=$(echo "$pro_json" | jq '.summary')
+
+        # Extract packages with available security updates
+        pro_packages=$(echo "$pro_json" | jq '[.packages[] | {
+            name: .package,
+            version: .version,
+            service: .service_name,
+            status: .status
+        }]' 2>/dev/null || echo "[]")
+        pro_vulnerable_count=$(echo "$pro_packages" | jq 'length' 2>/dev/null || echo 0)
+
+        if [[ "$pro_vulnerable_count" -gt 0 ]]; then
+            marvin_log "WARN" "Ubuntu Pro reports ${pro_vulnerable_count} package(s) with pending security updates"
+        else
+            marvin_log "INFO" "Ubuntu Pro: all packages up to date"
+        fi
+
+        # Check reboot requirement
+        reboot_required=$(echo "$pro_json" | jq -r '.summary.reboot_required // "no"' 2>/dev/null)
+        if [[ "$reboot_required" == "yes" ]]; then
+            marvin_log "WARN" "System reboot required for security updates"
+        fi
+    else
+        marvin_log "WARN" "pro security-status returned invalid data"
+    fi
+else
+    marvin_log "INFO" "Ubuntu Pro CLI not available — using apt only"
+fi
+
+# ─── 2. Apt security updates ────────────────────────────────────────────────
+
+apt_upgradable="[]"
+apt_security_count=0
+
+# Get list of upgradable packages
+apt_output=$(apt list --upgradable 2>/dev/null | tail -n +2 || echo "")
+if [[ -n "$apt_output" ]]; then
+    # Build JSON array using jq for safety
+    apt_upgradable=$(echo "$apt_output" | awk -F'/' '{
+        split($2, parts, " ");
+        printf "%s\t%s\t%s\n", $1, parts[1], parts[2]
+    }' | jq -Rn '[inputs | split("\t") | {name: .[0], repo: .[1], new_version: .[2]}]' 2>/dev/null || echo "[]")
+
+    # grep -c exits 1 on zero matches; || true prevents set -e from killing us
+    # while avoiding the "0\n0" double-output from || echo 0
+    apt_security_count=$(echo "$apt_output" | grep -c 'security' || true)
+    total_upgradable=$(echo "$apt_output" | wc -l | tr -d ' ')
+
+    if [[ "$apt_security_count" -gt 0 ]]; then
+        marvin_log "WARN" "${apt_security_count} security update(s) available (${total_upgradable} total upgradable)"
+    else
+        marvin_log "INFO" "${total_upgradable} package update(s) available (none security-critical)"
+    fi
+else
+    marvin_log "INFO" "All packages up to date"
+fi
+
+# ─── 3. Check for reboot-required marker ────────────────────────────────────
+
+reboot_needed="no"
+reboot_packages=""
+if [[ -f /var/run/reboot-required ]]; then
+    reboot_needed="yes"
+    if [[ -f /var/run/reboot-required.pkgs ]]; then
+        reboot_packages=$(cat /var/run/reboot-required.pkgs | head -20 | jq -Rs 'split("\n") | map(select(. != ""))' 2>/dev/null || echo "[]")
+    fi
+    marvin_log "WARN" "System reboot required"
+else
+    reboot_packages="[]"
+fi
+
+# ─── 4. Check unattended-upgrades status ────────────────────────────────────
+
+unattended_active=false
+unattended_last_run=""
+if systemctl is-active --quiet unattended-upgrades 2>/dev/null; then
+    unattended_active=true
+fi
+
+# Find last unattended-upgrades run
+uu_log="/var/log/unattended-upgrades/unattended-upgrades.log"
+if [[ -f "$uu_log" ]]; then
+    unattended_last_run=$(tail -5 "$uu_log" | grep -oP '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}' | tail -1 || echo "unknown")
+fi
+
+# ─── 5. Check kernel version against available ──────────────────────────────
+
+current_kernel=$(uname -r)
+latest_kernel=$(dpkg -l 'linux-image-*' 2>/dev/null | awk '/^ii.*linux-image-[0-9]/{print $2}' | sort -V | tail -1 | sed 's/linux-image-//' || echo "unknown")
+kernel_outdated=false
+if [[ "$current_kernel" != "$latest_kernel" && "$latest_kernel" != "unknown" ]]; then
+    kernel_outdated=true
+    marvin_log "INFO" "Running kernel ${current_kernel}, installed: ${latest_kernel}"
+fi
+
+# ─── 6. Generate report ─────────────────────────────────────────────────────
+
+# Determine overall CVE status
+cve_status="clean"
+if [[ "$pro_vulnerable_count" -gt 0 || "$apt_security_count" -gt 0 ]]; then
+    cve_status="updates_available"
+fi
+if [[ "$reboot_needed" == "yes" ]]; then
+    cve_status="reboot_required"
+fi
+
+cat > "$CVE_FILE" << EOF
+{
+  "timestamp": "${NOW}",
+  "status": "${cve_status}",
+  "ubuntu_pro": {
+    "available": ${pro_available},
+    "attached": $(echo "$pro_summary" | jq '.ua.attached // false' 2>/dev/null || echo false),
+    "vulnerable_packages": ${pro_vulnerable_count},
+    "packages": ${pro_packages},
+    "total_installed": $(echo "$pro_summary" | jq '.num_installed_packages // 0' 2>/dev/null || echo 0)
+  },
+  "apt": {
+    "security_updates": ${apt_security_count},
+    "upgradable": ${apt_upgradable}
+  },
+  "kernel": {
+    "running": "${current_kernel}",
+    "installed": "${latest_kernel}",
+    "outdated": ${kernel_outdated}
+  },
+  "reboot": {
+    "required": "${reboot_needed}",
+    "packages": ${reboot_packages}
+  },
+  "unattended_upgrades": {
+    "active": ${unattended_active},
+    "last_run": "${unattended_last_run}"
+  }
+}
+EOF
+
+# Validate the JSON
+if ! jq '.' "$CVE_FILE" &>/dev/null; then
+    marvin_log "ERROR" "CVE report JSON is invalid — regenerating minimal report"
+    cat > "$CVE_FILE" << EOF
+{
+  "timestamp": "${NOW}",
+  "status": "error",
+  "error": "Failed to generate valid JSON report"
+}
+EOF
+fi
+
+# Append to history for trend tracking
+jq -c '{timestamp: .timestamp, status: .status, pro_vulnerable: .ubuntu_pro.vulnerable_packages, apt_security: .apt.security_updates, reboot: .reboot.required}' "$CVE_FILE" >> "$CVE_HISTORY" 2>/dev/null || true
+
+marvin_log "INFO" "CVE monitor complete: status=${cve_status}, pro_vulns=${pro_vulnerable_count}, apt_security=${apt_security_count}, reboot=${reboot_needed}"

--- a/agent/lib/github.sh
+++ b/agent/lib/github.sh
@@ -391,7 +391,13 @@ github_upload_gpg_key() {
 # Usage: marvin_sign "message" → outputs detached signature
 marvin_sign() {
     local message="$1"
-    echo "$message" | gpg --armor --detach-sign 2>/dev/null
+    local key_id
+    key_id=$(marvin_gpg_key_id 2>/dev/null || echo "")
+    if [[ -n "$key_id" ]]; then
+        echo "$message" | gpg --armor --detach-sign --local-user "$key_id" 2>/dev/null
+    else
+        echo "$message" | gpg --armor --detach-sign 2>/dev/null
+    fi
 }
 
 # Verify a GPG signature

--- a/agent/security-scan.sh
+++ b/agent/security-scan.sh
@@ -132,7 +132,28 @@ else
     marvin_log "WARN" "file-integrity.sh not found — skipping"
 fi
 
-# ─── 5. Generate report ─────────────────────────────────────────────────────
+# ─── 5. CVE monitoring ───────────────────────────────────────────────────────
+
+CVE_SCRIPT="$(dirname "$0")/cve-monitor.sh"
+cve_status="skipped"
+cve_pro_vulns=0
+cve_apt_security=0
+
+if [[ -x "$CVE_SCRIPT" ]]; then
+    marvin_log "INFO" "Running CVE monitor..."
+    "$CVE_SCRIPT" 2>&1 || true
+
+    CVE_REPORT="${SECURITY_DIR}/cve-status.json"
+    if [[ -f "$CVE_REPORT" ]]; then
+        cve_status=$(jq -r '.status // "unknown"' "$CVE_REPORT" 2>/dev/null || echo "unknown")
+        cve_pro_vulns=$(jq '.ubuntu_pro.vulnerable_packages // 0' "$CVE_REPORT" 2>/dev/null || echo 0)
+        cve_apt_security=$(jq '.apt.security_updates // 0' "$CVE_REPORT" 2>/dev/null || echo 0)
+    fi
+else
+    marvin_log "WARN" "cve-monitor.sh not found — skipping"
+fi
+
+# ─── 6. Generate report ─────────────────────────────────────────────────────
 
 # Determine overall status
 overall_status="clean"
@@ -142,6 +163,8 @@ elif [[ "$fim_status" == "alert" ]]; then
     overall_status="alert"
 elif [[ "$rkhunter_status" == "warnings" || "$world_writable_count" -gt 0 ]]; then
     overall_status="warnings"
+elif [[ "$cve_status" == "updates_available" || "$cve_status" == "reboot_required" ]]; then
+    overall_status="updates_available"
 fi
 
 cat > "$REPORT_FILE" << EOF
@@ -165,6 +188,11 @@ cat > "$REPORT_FILE" << EOF
     "missing": ${fim_missing},
     "world_writable_count": ${world_writable_count},
     "suid_sgid_count": ${suid_count}
+  },
+  "cve": {
+    "status": "${cve_status}",
+    "pro_vulnerable": ${cve_pro_vulns},
+    "apt_security_updates": ${cve_apt_security}
   },
   "network": {
     "listening_ports": ${port_count}


### PR DESCRIPTION
## Summary

- **New `agent/cve-monitor.sh`** — Monitors installed packages for known CVEs using Ubuntu Pro `security-status` (primary) and `apt` (fallback). Tracks vulnerable packages, pending security updates, kernel currency, reboot requirements, and unattended-upgrades status. Outputs `data/security/cve-status.json` with JSONL history for trend tracking.
- **Integrated into `security-scan.sh`** — CVE data now included in daily security scan report alongside rkhunter, chkrootkit, and file integrity checks.
- **Fixed stuck rebase** — Aborted stale `REBASE_HEAD` from morning-check, fast-forwarded to origin/main.
- **Applied issue #39 fix** — `marvin_sign()` now uses `marvin_gpg_key_id()` to pass `--local-user` to GPG, preventing signing failures when multiple keys exist.
- **Updated file integrity baseline** after legitimate code changes.

## Test plan

- [x] `bash -n agent/cve-monitor.sh` passes
- [x] `bash -n agent/security-scan.sh` passes  
- [x] CVE monitor produces valid JSON (`jq .` validates)
- [x] No merge conflict markers in any agent script
- [x] Git state is clean on main after rebase fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)