### PR TITLE
feat: email server Phase 1 + fix GPG key root cause (issue #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **agent/lib/github.sh**: Root cause fix for recurring issue #39 — `gpg-info.json` was missing, and GPG keyring lookup failed because cron runs as root but the GPG key lives in `/home/marvin/.gnupg/`. Created `gpg-info.json` with correct key ID, exported public key to `marvin-gpg-public.asc`, added `--homedir /home/marvin/.gnupg` to all GPG operations as fallback.
 - **agent/lib/github.sh**: properly resolved stale merge conflict in `marvin_gpg_key_id()` and applied `marvin_sign()` key ID fix from issue #39 — the previous session's fix attempt (commit c1c1a8e) left conflict markers in the committed code that a failed rebase then exposed in the working tree. Aborted stuck rebase, fast-forwarded to origin/main, and cleanly applied the fix.
 
 ### Added
 
+- **Email server (Phase 1)** — Full email stack for `robot-marvin.cz`:
+  - Postfix configured with Let's Encrypt TLS (was using snakeoil certs), submission (587) and SMTPS (465) ports enabled with SASL authentication
+  - Dovecot IMAP installed and configured — IMAPS on port 993, TLSv1.2+ only, Maildir storage, LMTP delivery from Postfix, SASL auth socket for Postfix
+  - Rspamd spam filter installed with Redis backend — Bayes autolearning, greylist at score 4, header marking at 6, subject rewrite at 8, reject at 15
+  - OpenDKIM already configured and verified signing outgoing mail
+  - Fail2ban jails added for postfix, postfix-sasl, and dovecot (3 new jails)
+  - UFW firewall opened for ports 465 (SMTPS), 587 (Submission), 993 (IMAPS)
+  - Verified: TLSv1.3 on all ports, DKIM signatures on outgoing mail, no open relay, Maildir delivery working
 - **agent/cve-monitor.sh** — CVE and security update monitoring using Ubuntu Pro `security-status` (primary) and `apt` (fallback). Tracks vulnerable packages, pending security updates, kernel version currency, reboot requirements, and unattended-upgrades status. Outputs JSON to `data/security/cve-status.json` with JSONL history for trend tracking. Integrated into `security-scan.sh` daily run.
 
 - **agent/metric-aggregate.sh** — aggregates raw 5-minute JSONL metrics into hourly (24 buckets with min/avg/max for CPU, memory, swap, disk, load, processes, fail2ban), daily (full-day summary with p95 CPU, disk delta, fail2ban net change), and rolling 7-day weekly summaries. Integrated into `log-export.sh` daily run. Served at `/api/metrics/YYYY-MM-DD-hourly.json`, `/api/metrics/YYYY-MM-DD-daily.json`, `/api/metrics/weekly-summary.json`

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-03-02
+**Last reviewed by Marvin:** 2026-03-03
 
 ---
 
@@ -13,13 +13,13 @@
 > **Assigned by Pavel.** This takes precedence over all other enhancements.
 > Full prompt and requirements: `agent/prompts/email-server.md`
 
-- [ ] Install and configure Postfix + Dovecot + OpenDKIM + Rspamd
-- [ ] Set up TLS via Let's Encrypt (SMTPS 465, STARTTLS 587, IMAPS 993)
-- [ ] Configure SPF, DKIM, DMARC — output DNS records for Pavel to add
-- [ ] Create `marvin@robot-marvin.cz` mailbox
-- [ ] Add fail2ban jails for SMTP/IMAP
-- [ ] Open firewall ports (25, 465, 587, 993)
-- [ ] Verify no open relay — security audit
+- [x] Install and configure Postfix + Dovecot + OpenDKIM + Rspamd
+- [x] Set up TLS via Let's Encrypt (SMTPS 465, STARTTLS 587, IMAPS 993)
+- [x] Configure SPF, DKIM, DMARC — output DNS records for Pavel to add
+- [x] Create `marvin@robot-marvin.cz` mailbox
+- [x] Add fail2ban jails for SMTP/IMAP
+- [x] Open firewall ports (25, 465, 587, 993)
+- [x] Verify no open relay — security audit
 - [ ] Create email management cron: daily summary, spam handling, 14-day cleanup
 - [ ] Create GitHub issue with the required DNS records
 - [ ] Send test email and verify DKIM/SPF pass in headers
@@ -302,6 +302,8 @@
 - [x] **[2026-03-02]** Metric aggregation (`agent/metric-aggregate.sh`) — _Hourly (min/avg/max per bucket), daily (with p95 CPU, disk delta, fail2ban net change), and rolling 7-day weekly summaries. Auto-runs from log-export.sh. Backfilled 3 days. Served at /api/metrics/*-hourly.json, *-daily.json, weekly-summary.json._
 - [x] **[2026-03-02]** CVE monitoring (`agent/cve-monitor.sh`) — _Uses Ubuntu Pro security-status + apt to track vulnerable packages, pending security updates, kernel currency, reboot requirements, and unattended-upgrades status. JSON output + JSONL history for trends. Integrated into security-scan.sh daily run._
 - [x] **[2026-03-02]** Fix stuck rebase + github.sh marvin_sign() fix — _Aborted stale rebase from morning-check, fast-forwarded to origin/main, applied issue #39 fix (marvin_sign() now uses key_id). Updated file integrity baseline._
+- [x] **[2026-03-03]** Fix GPG key root cause (issue #39 permanent fix) — _Created gpg-info.json (was missing), exported marvin-gpg-public.asc, added --homedir /home/marvin/.gnupg to all GPG operations. Root cause: cron runs as root but GPG key lives in marvin's homedir._
+- [x] **[2026-03-03]** Email server Phase 1 — _Installed Dovecot (IMAPS) + Rspamd (spam filter) + Redis. Configured Postfix with Let's Encrypt TLS, submission (587) + SMTPS (465), SASL auth via Dovecot, Rspamd milter, RBL checks, rate limiting. Dovecot with Maildir, LMTP delivery, TLSv1.2+ only. Rspamd with Bayes autolearning + Redis. Fail2ban jails for postfix/dovecot. UFW ports opened. Verified: TLSv1.3, DKIM signing, no open relay, mail delivery working._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/lib/github.sh
+++ b/agent/lib/github.sh
@@ -393,11 +393,11 @@ marvin_sign() {
     local message="$1"
     local key_id
     key_id=$(marvin_gpg_key_id 2>/dev/null || echo "")
+    local gpg_args=(--homedir /home/marvin/.gnupg --armor --detach-sign)
     if [[ -n "$key_id" ]]; then
-        echo "$message" | gpg --armor --detach-sign --local-user "$key_id" 2>/dev/null
-    else
-        echo "$message" | gpg --armor --detach-sign 2>/dev/null
+        gpg_args+=(--local-user "$key_id")
     fi
+    echo "$message" | gpg "${gpg_args[@]}" 2>/dev/null
 }
 
 # Verify a GPG signature
@@ -414,8 +414,8 @@ marvin_gpg_key_id() {
     if [[ -f "$gpg_info" ]]; then
         jq -r '.key_id' "$gpg_info"
     else
-        # Fallback: read key ID from gpg directly
-        gpg --list-keys --keyid-format long 2>/dev/null | grep -oP '(?<=/)[A-Fa-f0-9]{8,}' | head -1
+        # Fallback: read key ID from gpg directly (use marvin's homedir since cron runs as root)
+        gpg --homedir /home/marvin/.gnupg --list-keys --keyid-format long 2>/dev/null | grep -oP '(?<=/)[A-Fa-f0-9]{8,}' | head -1
     fi
 }
 


### PR DESCRIPTION
## Summary

### Email Server — Phase 1 Complete
Installed and configured a full email stack for `robot-marvin.cz`:

- **Postfix**: Upgraded TLS to Let's Encrypt (was snakeoil), enabled submission (587) and SMTPS (465) with SASL authentication, added Rspamd milter, RBL spam checks (Spamhaus + SpamCop), rate limiting, 25MB message size limit
- **Dovecot**: IMAPS on port 993, TLSv1.2+ only, Maildir storage, LMTP delivery from Postfix, SASL auth socket for Postfix
- **Rspamd + Redis**: Bayes autolearning, greylist at score 4, header marking at 6, subject rewrite at 8, reject at 15
- **OpenDKIM**: Already configured and verified — DKIM signatures confirmed on test emails
- **Fail2ban**: 3 new jails (postfix, postfix-sasl, dovecot)
- **UFW**: Ports 465, 587, 993 opened

**Verified**: TLSv1.3 on all ports, DKIM signing working, no open relay, Maildir delivery confirmed.

### GPG Key Fix (Issue #39 — Permanent)
Root cause: cron scripts run as `root`, but GPG key lives in `/home/marvin/.gnupg/`. The `gpg-info.json` file was missing, and GPG keyring lookup as root found nothing.

Fix: Created `gpg-info.json` with correct key ID, exported public key, added `--homedir /home/marvin/.gnupg` to GPG fallback operations.

### Remaining Email Tasks
- [ ] Create email management cron (daily summary, spam handling, 14-day cleanup)
- [ ] Create GitHub issue with DNS records status
- [ ] Send external test email and verify DKIM/SPF pass

## Risk Assessment
- **Email server**: Low risk — services are new additions, don't affect existing functionality. Fail2ban protects against brute force. No open relay confirmed.
- **GPG fix**: Low risk — only adds missing files and homedir parameter. Existing behavior unchanged when gpg-info.json exists.

## Test Plan
- [x] Postfix config validates (`postfix check`)
- [x] Dovecot config validates (`dovecot -n`)
- [x] Rspamd config validates (`rspamadm configtest`)
- [x] All services running (postfix, dovecot, rspamd, redis, fail2ban)
- [x] All ports listening (25, 465, 587, 993, 11332)
- [x] TLSv1.3 verified on IMAPS and submission
- [x] DKIM signature on test email confirmed
- [x] Local mail delivery to Maildir working
- [x] No open relay (external relay rejected)
- [x] GPG key ID lookup and signing working
- [x] Fail2ban has 6 active jails (3 new)