### PR TITLE
fix: deduplicate swap logic, disable CUPS, update integrity baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Security
+
+- **CUPS snap disabled** — port 631 was bound to 0.0.0.0 (all interfaces), exposing the printing service to the internet. A VPS doesn't need CUPS. Disabled via `snap disable cups`. Removed from expected ports in `security-scan.sh`
+
+### Fixed
+
+- **agent/health-monitor.sh**: removed duplicated swap management logic — the `else` branches for both swap creation and expansion were retrying the identical `dd`/`mkswap`/`swapon` commands that just failed, which is pointless. Now logs error on first failure instead
+- **File integrity baseline**: updated after legitimate changes from issue #73 fix (health-monitor.sh, security-scan.sh, crontab)
+
 ### Added
 
 - **SLA / uptime tracking** in `agent/metric-aggregate.sh` — calculates daily uptime percentage from health check sample counts (expected 288 samples/day at 5-min intervals). Tracks last 30 days with per-day breakdown, overall uptime %, worst/best day, and days at 100%. Output at `data/metrics/sla.json`

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -70,17 +70,8 @@ if [[ -n "$mem_available" ]] && [[ "$mem_available" -lt 200 ]]; then
             marvin_log "INFO" "Created and activated 1GB swap file"
             ISSUES+=("INFO: Created 1GB swap file due to RAM pressure")
         else
-            marvin_log "WARN" "RAM pressure (${mem_available}MB available) and no swap — creating 1GB swap"
-            if dd if=/dev/zero of="${swap_file}" bs=1M count=1024 status=none 2>/dev/null \
-                && chmod 600 "${swap_file}" \
-                && mkswap "${swap_file}" >/dev/null 2>&1 \
-                && swapon "${swap_file}" 2>/dev/null; then
-                marvin_log "INFO" "Created and activated 1GB swap file"
-                ISSUES+=("INFO: Created 1GB swap file due to RAM pressure")
-            else
-                marvin_log "ERROR" "Failed to create swap file"
-                ISSUES+=("WARNING: Failed to create swap — low memory with no swap")
-            fi
+            marvin_log "ERROR" "Failed to create swap file (${mem_available}MB RAM available)"
+            ISSUES+=("WARNING: Failed to create swap — low memory with no swap")
         fi
     elif [[ "$current_swap_used_pct" -gt 80 && "$current_swap_mb" -lt 2048 ]]; then
         # Swap exists but is >80% used and under 2GB — try to expand
@@ -88,15 +79,6 @@ if [[ -n "$mem_available" ]] && [[ "$mem_available" -lt 200 ]]; then
         [[ "$new_size_mb" -gt 2048 ]] && new_size_mb=2048
         if [[ "$disk_free_mb" -lt $((new_size_mb + 200)) ]]; then
             marvin_log "WARN" "Insufficient disk space (${disk_free_mb}MB free) to expand swap to ${new_size_mb}MB — skipping"
-        else
-        marvin_log "WARN" "RAM pressure + swap ${current_swap_used_pct}% used — expanding swap to ${new_size_mb}MB"
-        swapoff "${swap_file}" 2>/dev/null || true
-        if dd if=/dev/zero of="${swap_file}" bs=1M count="$new_size_mb" status=none 2>/dev/null \
-            && chmod 600 "${swap_file}" \
-            && mkswap "${swap_file}" >/dev/null 2>&1 \
-            && swapon "${swap_file}" 2>/dev/null; then
-            marvin_log "INFO" "Expanded swap to ${new_size_mb}MB"
-            ISSUES+=("INFO: Expanded swap to ${new_size_mb}MB due to memory pressure")
         else
             marvin_log "WARN" "RAM pressure + swap ${current_swap_used_pct}% used — expanding swap to ${new_size_mb}MB"
             swapoff "${swap_file}" 2>/dev/null || true
@@ -112,7 +94,6 @@ if [[ -n "$mem_available" ]] && [[ "$mem_available" -lt 200 ]]; then
                 # Try to re-enable old swap
                 swapon "${swap_file}" 2>/dev/null || true
             fi
-        fi
         fi
     fi
 fi

--- a/agent/security-scan.sh
+++ b/agent/security-scan.sh
@@ -109,9 +109,10 @@ port_count=0
 # Expected ports baseline — alert on anything not in this list
 # Update this list when installing new services to avoid false-positive warnings.
 # 22=SSH, 25=SMTP, 53=DNS(systemd-resolved), 80=HTTP, 443=HTTPS,
-# 465=SMTPS, 587=STARTTLS, 631=CUPS(system dependency, localhost only), 993=IMAPS, 3000=Next.js,
+# 465=SMTPS, 587=STARTTLS, 993=IMAPS, 3000=Next.js,
 # 6379=Redis(local), 8043=alt-HTTPS, 11332-11334=Rspamd(local)
-EXPECTED_PORTS="22 25 53 80 443 465 587 631 993 3000 6379 8043 11332 11333 11334"
+# Note: CUPS snap (port 631) disabled 2026-03-06 — not needed on a VPS
+EXPECTED_PORTS="22 25 53 80 443 465 587 993 3000 6379 8043 11332 11333 11334"
 
 # Extract unique port numbers from listening sockets
 active_ports=$(echo "$listening_ports" | awk '{print $4}' | grep -oP '\d+$' | sort -un)
@@ -122,7 +123,7 @@ unexpected_count=0
 unexpected_details_json="[]"
 
 # Ports expected only on localhost — alert if bound to 0.0.0.0 or [::]
-LOCALHOST_ONLY_PORTS="631 6379 11332 11333 11334"
+LOCALHOST_ONLY_PORTS="6379 11332 11333 11334"
 
 for port in $active_ports; do
     if ! echo "$EXPECTED_PORTS" | grep -qw "$port"; then


### PR DESCRIPTION
## Summary

- **health-monitor.sh**: Removed duplicated swap creation/expansion retry blocks that were retrying the exact same `dd`/`mkswap`/`swapon` commands that just failed (artifact from a bad merge). Now logs error on first failure
- **security-scan.sh**: Removed port 631 from expected/localhost-only ports after disabling CUPS snap (a VPS has no printers, and port 631 was bound to 0.0.0.0)  
- **File integrity baseline**: Updated to clear false positives from issue #73 fix

## Test plan

- [x] `bash -n` syntax check passes for both modified scripts
- [x] Verified port 631 is no longer listening after `snap disable cups`
- [x] File integrity baseline updated (21 files monitored)

🤖 Generated autonomously by Marvin during self-enhancement session