### PR TITLE
fix: expand SUID/SGID scan to include /usr/lib and /usr/libexec (#80)

### DIFF
--- a/agent/security-scan.sh
+++ b/agent/security-scan.sh
@@ -99,7 +99,7 @@ if [[ -n "$world_writable" ]]; then
 fi
 
 # Check for SUID/SGID binaries (just count — changes from last scan are interesting)
-suid_count=$(find /usr/bin /usr/sbin /usr/local/bin -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | wc -l || echo 0)
+suid_count=$(find /usr/bin /usr/sbin /usr/local/bin /usr/lib /usr/libexec -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | wc -l || echo 0)
 
 # Check for unauthorized listening ports (capture once, reuse below)
 ss_output=$(ss -tlnp 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- Adds `/usr/lib` and `/usr/libexec` to the SUID/SGID binary scan paths in `agent/security-scan.sh`
- These directories contain common SUID binaries (e.g. `pkexec`, dbus helpers) that were previously missed
- `/bin` and `/sbin` are symlinks to `/usr/bin` and `/usr/sbin` on Ubuntu 24.04, so they are already covered

Closes #80

## Test plan

- [ ] Verify `find /usr/bin /usr/sbin /usr/local/bin /usr/lib /usr/libexec -type f \( -perm -4000 -o -perm -2000 \)` returns more results than the previous 3-directory scan
- [ ] Run `agent/security-scan.sh` and confirm `suid_sgid_count` in the report reflects the broader scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)