### PR TITLE
fix: reduce anomaly noise + fix-issues.sh reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Anomaly detection noise reduction** — CPU% and Load 1m were triggering false anomalies every 30 minutes. Added directional filtering (only alert on high CPU/Load, not low — idle is always fine) and minimum absolute thresholds (CPU must be >40% and Load must be >2x vCPUs before anomaly triggers). Memory and process count remain bidirectional.
+- **fix-issues.sh data/ false positive** — validation was checking all modified files including `data/` files changed by concurrent cron jobs (health-monitor every 5 min). Narrowed `CHANGED` to only track `agent/`, `web/`, and `*.md` files that are actually staged.
+- **fix-issues.sh cleanup trap unmerged state** — cleanup trap's `git checkout -- .` failed on unmerged files from stash pop conflicts, leaving repo stuck on fix branches. Added `git reset HEAD` before checkout to clear unmerged index state.
+- **Git unmerged files** — resolved stuck `fix/issues-*` branch with unmerged `health-monitor.sh` that was blocking `morning-check.sh` git pull. Restored main, fast-forwarded to origin, cleaned up stale branches
 - **Merge conflict in file-integrity.sh** — resolved <<<<<<< conflict markers from stash/pop collision during morning-check. Added caller tracking to `--update` mode (logs which process triggered baseline reset with PID)
 - **ps false positive in runaway detection** — despite case-statement exclusion, `ps` at 100% was logged ~30 times/day. Added awk pre-filter in the pipeline to exclude `ps`/`awk`/`sort` before the while loop
-- **Git unmerged files** — resolved stuck `fix/issues-*` branch with unmerged `health-monitor.sh` that was blocking `morning-check.sh` git pull. Restored main, fast-forwarded to origin, cleaned up stale branches
 - **Git repo health**: resolved stuck rebase on `fix/issues-*` branch with stale REBASE_HEAD, cleaned 27 stale local branches accumulated from merged PRs, fast-forwarded main to origin
 - **File integrity baseline**: updated after upstream pulls
 - **Runaway process detection**: added `fail2ban*` to exclusion list in `health-monitor.sh` (it flags itself during monitoring). Removed `curl` and `git*` from exclusions after review — the 10-minute tracking window handles their transient spikes while preserving detection of genuinely stuck or malicious processes (PR #144, review fixes for #147)

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-03-09
+**Last reviewed by Marvin:** 2026-03-10
 
 ---
 

--- a/agent/fix-issues.sh
+++ b/agent/fix-issues.sh
@@ -28,7 +28,8 @@ cleanup() {
     local current_branch
     current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
     if [[ "$current_branch" != "main" ]]; then
-        # Discard any uncommitted changes on the fix branch
+        # Reset index and discard all changes (handles unmerged state too)
+        git reset HEAD 2>/dev/null || true
         git checkout -- . 2>/dev/null || true
         git clean -fd agent/ web/ 2>/dev/null || true
         git checkout main 2>/dev/null || true
@@ -40,6 +41,7 @@ cleanup() {
     # Restore any stashed changes (safe pop to prevent conflict marker ghosts)
     if ! git stash pop --quiet 2>/dev/null; then
         if git diff --name-only --diff-filter=U 2>/dev/null | grep -q .; then
+            git reset HEAD 2>/dev/null || true
             git checkout -- . 2>/dev/null || true
             git stash drop --quiet 2>/dev/null || true
         fi
@@ -138,7 +140,9 @@ OUTPUT=$(run_claude "fix-issues" "$FULL_PROMPT")
 
 # ─── Check for changes ──────────────────────────────────────────────────────
 
-CHANGED=$(git diff --name-only 2>/dev/null || echo "")
+# Only track changes in directories we'll actually stage (agent/, web/, *.md)
+# Concurrent cron jobs modify data/ files — those are never staged so ignore them
+CHANGED=$(git diff --name-only -- agent/ web/ *.md 2>/dev/null || echo "")
 UNTRACKED=$(git ls-files --others --exclude-standard -- agent/ web/ 2>/dev/null || echo "")
 
 if [[ -z "$CHANGED" && -z "$UNTRACKED" ]]; then

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -29,15 +29,29 @@ _ANOMALY_DETAILS=()
 
 _anomaly_check() {
     local label="$1" current="$2" avg="$3" stddev="$4"
+    # $5 = direction: "high" (only alert above avg), "both" (default)
+    # $6 = min_threshold: minimum absolute value before alerting (e.g., CPU must be >50)
+    local direction="${5:-both}" min_threshold="${6:-0}"
     local is_anomaly=false deviation="0"
+
+    # Skip if current is below the minimum absolute threshold
+    # e.g., CPU=4% is never concerning regardless of deviation from average
+    if awk -v cur="$current" -v thr="$min_threshold" 'BEGIN{exit (cur < thr) ? 0 : 1}' 2>/dev/null; then
+        return
+    fi
 
     # When stddev is too small (< 1), use absolute percentage deviation instead
     # This prevents masking large deviations on normally-stable metrics (#153)
     if awk -v sd="$stddev" 'BEGIN{exit (sd < 1) ? 0 : 1}' 2>/dev/null; then
         # Fallback: flag if current deviates >20% from mean (and mean is non-trivial)
-        local pct_dev
-        pct_dev=$(awk -v cur="$current" -v mean="$avg" \
-            'BEGIN{if(mean==0){printf "0"}else{d=(cur-mean)/mean; if(d<0)d=-d; printf "%.1f", d*100}}' 2>/dev/null || echo "0")
+        local pct_dev raw_dev
+        raw_dev=$(awk -v cur="$current" -v mean="$avg" \
+            'BEGIN{if(mean==0){printf "0"}else{printf "%.1f", (cur-mean)/mean*100}}' 2>/dev/null || echo "0")
+        pct_dev=$(awk -v d="$raw_dev" 'BEGIN{if(d<0)d=-d; printf "%.1f", d}' 2>/dev/null || echo "0")
+        # Direction filter: skip negative deviations when direction=high
+        if [[ "$direction" == "high" ]] && awk -v d="$raw_dev" 'BEGIN{exit (d < 0) ? 0 : 1}' 2>/dev/null; then
+            return
+        fi
         if awk -v pd="$pct_dev" 'BEGIN{exit (pd > 20.0) ? 0 : 1}' 2>/dev/null; then
             deviation="${pct_dev}%"
             is_anomaly=true
@@ -45,6 +59,10 @@ _anomaly_check() {
     else
         deviation=$(awk -v cur="$current" -v mean="$avg" -v sd="$stddev" \
             'BEGIN{printf "%.1f", (cur - mean) / sd}' 2>/dev/null || echo "0")
+        # Direction filter: skip negative deviations when direction=high
+        if [[ "$direction" == "high" ]] && awk -v d="$deviation" 'BEGIN{exit (d < 0) ? 0 : 1}' 2>/dev/null; then
+            return
+        fi
         local abs_dev
         abs_dev=$(awk -v d="$deviation" 'BEGIN{if(d<0) d=-d; printf "%.1f", d}' 2>/dev/null || echo "0")
         if awk -v ad="$abs_dev" 'BEGIN{exit (ad > 2.0) ? 0 : 1}' 2>/dev/null; then
@@ -87,15 +105,24 @@ if [[ ${#_daily_files[@]} -ge 3 ]]; then
     _proc_avgs=$(for f in "${_daily_files[@]}"; do jq -r '.summary.process_count.avg // empty' "$f" 2>/dev/null; done)
 
     # Compute mean and stddev, then check current values
+    # Format: label|values|current|direction|min_threshold
+    #   direction: "high" = only alert above average, "both" = alert either way
+    #   min_threshold: minimum absolute value before the metric is worth alerting on
+    _vcpus=$(nproc 2>/dev/null || echo 2)
+    _load_min_threshold=$(( _vcpus * 2 ))  # load < 2x vCPUs is never anomalous
     for pair in \
-        "CPU%|${_cpu_avgs}|$(echo "$metrics" | jq -r '.cpu_percent' 2>/dev/null)" \
-        "Memory MB|${_mem_avgs}|$(echo "$metrics" | jq -r '.memory.used' 2>/dev/null)" \
-        "Load 1m|${_load_avgs}|$(echo "$metrics" | jq -r '.load_average["1min"]' 2>/dev/null)" \
-        "Processes|${_proc_avgs}|$(echo "$metrics" | jq -r '.process_count' 2>/dev/null)"; do
+        "CPU%|${_cpu_avgs}|$(echo "$metrics" | jq -r '.cpu_percent' 2>/dev/null)|high|40" \
+        "Memory MB|${_mem_avgs}|$(echo "$metrics" | jq -r '.memory.used' 2>/dev/null)|both|0" \
+        "Load 1m|${_load_avgs}|$(echo "$metrics" | jq -r '.load_average["1min"]' 2>/dev/null)|high|${_load_min_threshold}" \
+        "Processes|${_proc_avgs}|$(echo "$metrics" | jq -r '.process_count' 2>/dev/null)|both|0"; do
         _label="${pair%%|*}"
         _rest="${pair#*|}"
         _vals="${_rest%%|*}"
-        _current="${_rest##*|}"
+        _rest2="${_rest#*|}"
+        _current="${_rest2%%|*}"
+        _rest3="${_rest2#*|}"
+        _direction="${_rest3%%|*}"
+        _min_thr="${_rest3##*|}"
 
         [[ -z "$_current" || "$_current" == "null" ]] && continue
 
@@ -109,7 +136,7 @@ if [[ ${#_daily_files[@]} -ge 3 ]]; then
         _mean="${_stats%% *}"
         _sd="${_stats##* }"
 
-        _anomaly_check "$_label" "$_current" "$_mean" "$_sd"
+        _anomaly_check "$_label" "$_current" "$_mean" "$_sd" "$_direction" "$_min_thr"
     done
 
     # Write anomaly status for dashboard consumption (includes anomaly details)


### PR DESCRIPTION
## Summary

Three targeted fixes for recurring daily issues identified from log analysis:

### 1. Anomaly detection noise reduction (`health-monitor.sh`)
- **Problem:** CPU% and Load 1m anomalies fired every 30 minutes because idle readings (0-4.5%) deviate significantly from the daily average (11%). Low CPU/Load is perfectly normal — only HIGH values indicate problems.
- **Fix:** Added directional filtering (`high` = only alert above average) and minimum absolute thresholds (CPU must be >40%, Load must be >2x vCPUs). Memory and process count remain bidirectional.
- **Impact:** Eliminates ~20 false anomaly warnings per day.

### 2. fix-issues.sh data/ validation false positive
- **Problem:** `CHANGED=$(git diff --name-only)` captured ALL modified files, including `data/` files modified by concurrent cron jobs (health-monitor runs every 5 min). Validation rejected these as "forbidden file modified" even though they're never staged.
- **Fix:** Narrowed `CHANGED` to only `agent/`, `web/`, and `*.md` — the directories actually staged for commit.

### 3. fix-issues.sh cleanup trap unmerged state
- **Problem:** Cleanup trap used `git checkout -- .` which fails on unmerged files from stash pop conflicts, leaving the repo stuck on fix branches.
- **Fix:** Added `git reset HEAD` before checkout to clear unmerged index state.

## Test plan
- [ ] Verify health-monitor.sh runs without syntax errors
- [ ] Verify no CPU% anomaly alerts when CPU is idle (<40%)
- [ ] Verify fix-issues.sh can run with concurrent health-monitor writing to data/
- [ ] Verify cleanup trap returns to main even after conflict

---
*Automated enhancement by Marvin's self-enhance session.*