### PR TITLE
fix: restrict sensitive API data + reduce anomaly noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Security
+
+- **Restrict public access to sensitive data** — added nginx deny rules for `/api/security/` and `/api/email/` directories. Security scan results (port inventories, CVE status, rootkit scans) and email metadata (sender/subject) were publicly accessible via the `/api/` catch-all alias. Now return 403. Other API data (metrics, status, exports, comms) remains public. (closes #117, #120)
+
+### Fixed
+
+- **Process count anomaly false positives** — process count was triggering 6-8 false anomaly alerts per day because the 7-day rolling stddev (2.80) was much tighter than actual intraday range (149-172). Changed direction to "high" (low process count is never concerning) and added min_threshold=200 (process counts under 200 are normal for a 2-vCPU server). Reduces noise from ~8 alerts/day to near zero while still detecting genuine fork bombs or runaway spawning.
+- **File integrity baseline** — updated baseline after legitimate changes from merged PRs (common.sh, health-monitor.sh) were triggering persistent false-positive alerts since 2026-03-09.
+
 ### Added
 
 - **Weekly analytics report** (`agent/weekly-analytics.sh`) — data-driven weekly report with system metrics trends, Claude API usage stats, log error analysis, security summary, SLA tracking, and enhancement activity. Generates both JSON (`data/reports/weekly-YYYY-MM-DD.json`) and human-readable markdown digest. Includes week-over-week comparison deltas. Runs Sundays at 11:30 UTC via cron. No Claude API calls — pure data aggregation.

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-03-10
+**Last reviewed by Marvin:** 2026-03-11
 
 ---
 
@@ -327,6 +327,9 @@
 - [x] **[2026-03-09]** Mark JSONL time-series + Claude API usage tracking as complete — _JSONL metrics files since 2026-02-28, claude-usage-YYYY-MM-DD.jsonl tracking since 2026-03-07. Both already implemented in common.sh._
 - [x] **[2026-03-10]** Weekly analytics report (`agent/weekly-analytics.sh`) — _Data-driven weekly report: system metrics trends with WoW deltas, Claude API usage stats (runs/duration/errors by task), log error analysis (top recurring errors), security score, SLA tracking, enhancement count. JSON + markdown output. Cron Sundays 11:30 UTC. No Claude API calls._
 - [x] **[2026-03-10]** Network I/O metrics in collect_metrics() — _Added rx_bytes, tx_bytes, rx_packets, tx_packets from /proc/net/dev for primary interface. Feeds into existing JSONL metrics pipeline. Foundation for Phase 3 bandwidth monitoring._
+- [x] **[2026-03-11]** Restrict security/email data from public nginx — _Added deny rules for /api/security/ and /api/email/ in nginx config. Security scans, port inventories, CVE data, and email metadata were publicly accessible. Now return 403. Closes #117, #120._
+- [x] **[2026-03-11]** Fix process count anomaly false positives — _Changed direction to "high" + min_threshold=200. Low process count (151-152 vs avg 158) was triggering 6-8 false alerts/day. Only high counts above 200 are now flagged._
+- [x] **[2026-03-11]** Update file integrity baseline — _Cleared 2 false-positive alerts from legitimate PR merges (common.sh, health-monitor.sh changed since 2026-03-09 baseline)._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -114,7 +114,7 @@ if [[ ${#_daily_files[@]} -ge 3 ]]; then
         "CPU%|${_cpu_avgs}|$(echo "$metrics" | jq -r '.cpu_percent' 2>/dev/null)|high|40" \
         "Memory MB|${_mem_avgs}|$(echo "$metrics" | jq -r '.memory.used' 2>/dev/null)|both|0" \
         "Load 1m|${_load_avgs}|$(echo "$metrics" | jq -r '.load_average["1min"]' 2>/dev/null)|high|${_load_min_threshold}" \
-        "Processes|${_proc_avgs}|$(echo "$metrics" | jq -r '.process_count' 2>/dev/null)|both|0"; do
+        "Processes|${_proc_avgs}|$(echo "$metrics" | jq -r '.process_count' 2>/dev/null)|high|200"; do
         _label="${pair%%|*}"
         _rest="${pair#*|}"
         _vals="${_rest%%|*}"


### PR DESCRIPTION
## Summary

- **Security**: Block public access to `/api/security/` and `/api/email/` via nginx deny rules (closes #117, #120). Security scans, port inventories, CVE data, and email metadata were publicly accessible.
- **Stability**: Fix process count anomaly false positives in `health-monitor.sh` — changed direction to `high` + `min_threshold=200`. Eliminates ~8 false alerts/day.
- **Maintenance**: Update file integrity baseline to clear false-positive alerts.

## Changed Files

- `agent/health-monitor.sh` — process count anomaly: `both|0` to `high|200`
- `CHANGELOG.md` — documented changes
- `POSSIBLE_ENHANCEMENTS.md` — marked 3 items complete

## Validation

- [x] `bash -n` passes on all agent scripts
- [x] `nginx -t` passes, reloaded, verified 403 on sensitive endpoints
- [x] File integrity check clean after baseline update
- [x] GPG-signed commit

---
*Automated enhancement by Marvin self-enhance agent (2026-03-11)*