### PR TITLE
fix: resolve GPG signing loop and metric-aggregate dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **GPG signing failure loop in fix-issues.sh** — `fix-issues.sh` runs as root via cron but GPG keys live in `/home/marvin/.gnupg/`. Without `GNUPGHOME` set, `git commit -S` failed with "No secret key" every run, killing the script under `set -e`. The cleanup trap silently reverted all changes, and the "Fixed issue" log message (printed before the commit) made it look like success. Result: issue #105 was "fixed" 3+ times daily but never actually committed. Fix: export `GNUPGHOME=/home/marvin/.gnupg` in `common.sh` (fixes all scripts), add explicit error handling for `git commit -S` in `fix-issues.sh`, and move success log to after commit.
+- **metric-aggregate.sh jq error handling dead code (issue #105)** — three `if [[ $? -eq 0 ]]` checks after `jq` commands were unreachable under `set -euo pipefail` because a failing `jq` would exit the script before `$?` could be tested. Replaced with `|| flag=false` pattern to capture jq failures without triggering `set -e`.
+- **fix-issues.sh cleanup trap diagnostics** — trap handler now logs non-zero exit codes, making silent failures visible in daily logs.
+
 ### Security
 
 - **Restrict public access to sensitive data** — added nginx deny rules for `/api/security/` and `/api/email/` directories. Security scan results (port inventories, CVE status, rootkit scans) and email metadata (sender/subject) were publicly accessible via the `/api/` catch-all alias. Now return 403. Other API data (metrics, status, exports, comms) remains public. (closes #117, #120)

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-03-11
+**Last reviewed by Marvin:** 2026-03-12
 
 ---
 
@@ -330,6 +330,8 @@
 - [x] **[2026-03-11]** Restrict security/email data from public nginx — _Added deny rules for /api/security/ and /api/email/ in nginx config. Security scans, port inventories, CVE data, and email metadata were publicly accessible. Now return 403. Closes #117, #120._
 - [x] **[2026-03-11]** Fix process count anomaly false positives — _Changed direction to "high" + min_threshold=200. Low process count (151-152 vs avg 158) was triggering 6-8 false alerts/day. Only high counts above 200 are now flagged._
 - [x] **[2026-03-11]** Update file integrity baseline — _Cleared 2 false-positive alerts from legitimate PR merges (common.sh, health-monitor.sh changed since 2026-03-09 baseline)._
+- [x] **[2026-03-12]** Fix GPG signing failure loop (GNUPGHOME in common.sh) — _Root cause of fix-issues.sh loop: cron runs as root but GPG key lives in /home/marvin/.gnupg. Export GNUPGHOME globally in common.sh. Also fixed fix-issues.sh error handling: explicit commit failure check, moved success log after commit, added exit code to cleanup trap._
+- [x] **[2026-03-12]** Fix metric-aggregate.sh jq dead code (issue #105) — _Three `if [[ $? -eq 0 ]]` after jq were unreachable under set -e. Replaced with `|| flag=false` pattern. This was the issue fix-issues.sh kept trying and failing to commit._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -6,6 +6,10 @@
 MARVIN_DIR="/home/marvin/git"
 DATA_DIR="${MARVIN_DIR}/data"
 LOGS_DIR="${DATA_DIR}/logs"
+
+# GPG key lives in marvin's homedir, but cron runs as root.
+# Without this, git commit -S and gpg --detach-sign fail with "No secret key".
+export GNUPGHOME="/home/marvin/.gnupg"
 METRICS_DIR="${DATA_DIR}/metrics"
 BLOG_DIR="/home/marvin/blog"
 COMMS_DIR="${DATA_DIR}/comms"

--- a/agent/fix-issues.sh
+++ b/agent/fix-issues.sh
@@ -24,6 +24,9 @@ LOCK_FILE="/tmp/marvin-fix-issues.lock"
 
 cleanup() {
     local exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then
+        marvin_log "WARN" "fix-issues exiting with code ${exit_code}" 2>/dev/null || true
+    fi
     cd "$MARVIN_DIR" 2>/dev/null || true
     local current_branch
     current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
@@ -211,7 +214,7 @@ if [[ -z "$FIXED_ISSUE" ]]; then
     FIXED_ISSUE=$(echo "$OUTPUT" | grep -oP '#(\d+)' | head -1 | tr -d '#' || echo "")
 fi
 
-marvin_log "INFO" "Fixed issue: #${FIXED_ISSUE:-unknown} — ${FIXED_TITLE}"
+marvin_log "INFO" "Attempting fix for issue: #${FIXED_ISSUE:-unknown} — ${FIXED_TITLE}"
 
 # ─── Stage and commit ────────────────────────────────────────────────────────
 
@@ -236,8 +239,14 @@ ${FIX_DESCRIPTION}
 Automated fix by Marvin's issue-fixer agent.
 Validated: bash syntax OK, no conflict markers, no forbidden files."
 
-git commit -S -m "$COMMIT_MSG" 2>&1
-marvin_log "INFO" "Committed fix on branch ${BRANCH}"
+# GPG signing requires GNUPGHOME (set in common.sh). Handle failure explicitly
+# instead of letting set -e kill the script silently (this was causing a loop
+# where fixes were reverted by the cleanup trap with no error log).
+if ! git commit -S -m "$COMMIT_MSG" 2>&1; then
+    marvin_log "ERROR" "git commit -S failed for issue #${FIXED_ISSUE:-unknown} (GPG signing may have failed)"
+    exit 1
+fi
+marvin_log "INFO" "Committed fix on branch ${BRANCH}: #${FIXED_ISSUE:-unknown} — ${FIXED_TITLE}"
 
 # ─── Push, create PR, merge ─────────────────────────────────────────────────
 

--- a/agent/metric-aggregate.sh
+++ b/agent/metric-aggregate.sh
@@ -37,6 +37,9 @@ marvin_log "INFO" "Processing ${LINE_COUNT} data points from ${JSONL_FILE}"
 # ─── Hourly aggregation ─────────────────────────────────────────────────────
 # Group metrics by hour, compute min/avg/max for key fields
 
+# Under set -e, a failing jq would kill the script before $? is checked.
+# Use && / || to capture the exit code without triggering set -e.
+hourly_ok=true
 jq -s '
   # Parse hour from timestamp
   map(. + {hour: (.timestamp | split("T")[1] | split(":")[0] | tonumber)})
@@ -85,9 +88,9 @@ jq -s '
       }
     })
   | sort_by(.hour)
-' "$JSONL_FILE" > "${HOURLY_FILE}.tmp" 2>/dev/null
+' "$JSONL_FILE" > "${HOURLY_FILE}.tmp" 2>/dev/null || hourly_ok=false
 
-if [[ $? -eq 0 ]] && jq empty "${HOURLY_FILE}.tmp" 2>/dev/null; then
+if [[ "$hourly_ok" == "true" ]] && jq empty "${HOURLY_FILE}.tmp" 2>/dev/null; then
     # Wrap in metadata envelope
     jq -n \
         --arg date "$TARGET_DATE" \
@@ -110,6 +113,7 @@ fi
 # ─── Daily aggregation ───────────────────────────────────────────────────────
 # Single summary for the entire day
 
+daily_ok=true
 jq -s '
   {
     samples: length,
@@ -160,9 +164,9 @@ jq -s '
     },
     uptime_hours: ((last.uptime_seconds - first.uptime_seconds) / 3600 | . * 10 | round / 10)
   }
-' "$JSONL_FILE" > "${DAILY_FILE}.tmp" 2>/dev/null
+' "$JSONL_FILE" > "${DAILY_FILE}.tmp" 2>/dev/null || daily_ok=false
 
-if [[ $? -eq 0 ]] && jq empty "${DAILY_FILE}.tmp" 2>/dev/null; then
+if [[ "$daily_ok" == "true" ]] && jq empty "${DAILY_FILE}.tmp" 2>/dev/null; then
     jq -n \
         --arg date "$TARGET_DATE" \
         --arg generated "$NOW" \
@@ -195,6 +199,7 @@ done
 
 if [[ ${#WEEKLY_DAYS[@]} -gt 0 ]]; then
     # Merge daily summaries into weekly view
+    weekly_ok=true
     jq -s '
       map({date: .date, summary: .summary})
       | sort_by(.date)
@@ -210,9 +215,9 @@ if [[ ${#WEEKLY_DAYS[@]} -gt 0 ]]; then
             process_count_avg: ([.[].summary.process_count.avg] | add / length | round)
           }
         }
-    ' "${WEEKLY_DAYS[@]}" > "${WEEKLY_FILE}.tmp" 2>/dev/null
+    ' "${WEEKLY_DAYS[@]}" > "${WEEKLY_FILE}.tmp" 2>/dev/null || weekly_ok=false
 
-    if [[ $? -eq 0 ]] && jq empty "${WEEKLY_FILE}.tmp" 2>/dev/null; then
+    if [[ "$weekly_ok" == "true" ]] && jq empty "${WEEKLY_FILE}.tmp" 2>/dev/null; then
         jq --arg generated "$NOW" '. + {generated_at: $generated}' \
             "${WEEKLY_FILE}.tmp" > "$WEEKLY_FILE"
         rm -f "${WEEKLY_FILE}.tmp"


### PR DESCRIPTION
## Summary

- **Root cause fix**: Export `GNUPGHOME=/home/marvin/.gnupg` in `common.sh` so all cron scripts (running as root) can access Marvin's GPG key for commit signing
- **fix-issues.sh**: Explicit error handling for `git commit -S`, moved success log after commit, added exit code logging to cleanup trap
- **metric-aggregate.sh**: Fixed three dead-code `if [[ $? -eq 0 ]]` checks after `jq` commands (unreachable under `set -e`)

## Context

`fix-issues.sh` was stuck in an infinite loop: every 2 hours it would pick issue #105, apply the correct fix, but `git commit -S` silently failed because root couldn't find the GPG key. The cleanup trap reverted everything, and the misleading log ("Fixed issue: #105") made it look like success. This consumed Claude API credits 3+ times daily with zero progress.

## Test plan

- [x] All 3 modified scripts pass `bash -n` syntax check
- [x] `metric-aggregate.sh` tested against 288-sample day (2026-03-11) — all aggregations succeed
- [x] GPG signing verified: `echo "test" | gpg --homedir /home/marvin/.gnupg --armor --detach-sign` works as root
- [ ] Monitor next `fix-issues.sh` cron run to verify commits land

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)