### PR TITLE
fix: #165 forbidden file check skips untracked files

### DIFF
--- a/agent/fix-issues.sh
+++ b/agent/fix-issues.sh
@@ -183,7 +183,7 @@ while IFS= read -r f; do
     fi
 done < <(printf '%s\n%s\n' "$CHANGED" "$UNTRACKED")
 
-# 3. Check that no data/ or runtime files were modified
+# 3. Check that no data/ or runtime files were modified (changed AND untracked)
 while IFS= read -r f; do
     [[ -n "$f" ]] || continue
     case "$f" in
@@ -193,7 +193,7 @@ while IFS= read -r f; do
             marvin_log "ERROR" "VALIDATION FAILED: forbidden file modified: $f"
             ;;
     esac
-done <<< "$CHANGED"
+done < <(printf '%s\n%s\n' "$CHANGED" "$UNTRACKED")
 
 if [[ "$VALID" != "true" ]]; then
     marvin_log "ERROR" "Validation failed — aborting fix. Errors: ${VALIDATION_ERRORS}"


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #165 — bug: forbidden file check in fix-issues.sh skips untracked files

**Fix:** The forbidden file type check (`data/*`, `*.db`, `*.db-*`, `*.log`) only iterated over `$CHANGED` (tracked modified files) but not `$UNTRACKED` (newly created files). Changed the here-string input to use process substitution with `printf '%s\n%s\n' "$CHANGED" "$UNTRACKED"` — the same pattern already used by the conflict-marker check in the adjacent loop.

### Changed Files
```
agent/fix-issues.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #165*