### PR TITLE
fix: #106 bug: metric-aggregate.sh — wc -l whitespace causes --argjson

### DIFF
--- a/agent/metric-aggregate.sh
+++ b/agent/metric-aggregate.sh
@@ -31,7 +31,7 @@ WEEKLY_FILE="${METRICS_DIR}/weekly-summary.json"
 
 marvin_log "INFO" "Aggregating metrics for ${TARGET_DATE}"
 
-LINE_COUNT=$(wc -l < "$JSONL_FILE")
+LINE_COUNT=$(wc -l < "$JSONL_FILE" | tr -d ' ')
 marvin_log "INFO" "Processing ${LINE_COUNT} data points from ${JSONL_FILE}"
 
 # ─── Hourly aggregation ─────────────────────────────────────────────────────
@@ -244,7 +244,7 @@ _calculate_day_uptime() {
     [[ -f "$jsonl" ]] || return 0
 
     local samples
-    samples=$(wc -l < "$jsonl")
+    samples=$(wc -l < "$jsonl" | tr -d ' ')
     [[ "$samples" -gt 0 ]] || return 0
 
     # Get first and last timestamps to determine the observation window


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #106 — bug: metric-aggregate.sh — wc -l whitespace causes --argjson to fail

**Fix:** Pipe wc -l output through tr -d ' ' to strip leading whitespace on line 34 (LINE_COUNT) and line 247 (samples in _calculate_day_uptime), preventing jq --argjson parse failures.

### Changed Files
```
agent/metric-aggregate.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #106*