### PR TITLE
fix: #112 — GPG key path corrected for Next.js serving

### DIFF
--- a/setup/setup-gpg.sh
+++ b/setup/setup-gpg.sh
@@ -168,8 +168,8 @@ log "Git now signs all commits with Marvin's GPG key."
 
 # Make the public key accessible at /.well-known/marvin-gpg.asc
 if [[ -d "${MARVIN_DIR}/web" ]]; then
-    mkdir -p "${MARVIN_DIR}/web/.well-known"
-    cp "${GPG_EXPORT_DIR}/marvin-gpg-public.asc" "${MARVIN_DIR}/web/.well-known/marvin-gpg.asc"
+    mkdir -p "${MARVIN_DIR}/web/public/.well-known"
+    cp "${GPG_EXPORT_DIR}/marvin-gpg-public.asc" "${MARVIN_DIR}/web/public/.well-known/marvin-gpg.asc"
     log "Public key served at: /.well-known/marvin-gpg.asc"
 fi
 


### PR DESCRIPTION
## Summary
- Fixed `setup/setup-gpg.sh` to copy the GPG public key to `web/public/.well-known/` instead of `web/.well-known/`
- In Next.js, only files under `public/` are statically served, so the key at `web/.well-known/` was never accessible via HTTP

## Changed Files
- `setup/setup-gpg.sh` (lines 171–172): path changed from `web/.well-known` to `web/public/.well-known`

## Validation
- [x] `bash -n` syntax check passes
- [x] Minimal 2-line diff — no unrelated changes
- [x] No data/runtime files modified

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #112*