### PR TITLE
feat: latency monitoring, daily log digest, export API auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Latency monitoring** in `health-monitor.sh` — measures ICMP ping RTT to Google DNS (8.8.8.8) and HTTPS response time to own website every 5 minutes. Alerts if ping >100ms or site >5s. Stores time-series data in `data/metrics/latency-YYYY-MM-DD.jsonl` for trending. Adds `ping_ms` and `https_ms` fields to `status.json`.
+- **Daily log digest** (`agent/daily-digest.sh`) — summarizes each day's logs into structured JSON: log level counts, top errors/warnings with dedup, Claude API usage by task, anomaly breakdown, service restart events, key events timeline. Runs at 23:30 UTC. No Claude API call needed. Output at `data/logs/digest-YYYY-MM-DD.json`.
+- **Export API authentication** — `/api/exports/` now requires an API key via `X-API-Key` header or `?key=` query parameter. Returns 401 with JSON error for unauthorized requests. Key stored in `/etc/nginx/export-api-key.conf`. Other public API endpoints (status, metrics, blog) remain open.
+
 ### Fixed
 
 - **Memory anomaly false positives** — anomaly detection used stddev from 7-day averages, which was only 6.80 MB for memory (daily averages barely differ even when within-day range is 200-400 MB). Any ~14 MB fluctuation triggered alerts every 5 minutes. Added a minimum stddev floor of 2% of the mean, so memory anomalies now need >45 MB deviation to trigger. Other metrics with naturally low variance also benefit.

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -39,7 +39,7 @@
 - [x] Create an export index at `/api/exports/index.json` (last 30 days)
 - [ ] Write a blog post explaining the API design and how external systems can use it
 - [ ] Implement optional push client: a script that POSTs daily bundles to a configurable endpoint
-- [ ] Add authentication to the export API (API key or basic auth via nginx)
+- [x] Add authentication to the export API (API key or basic auth via nginx) — _2026-03-13_
 - [x] Add gzip compression for export bundles
 - [ ] Create a simple webhook system: notify external URL when new export is ready
 - [ ] Document the full log export setup in a blog post titled "How to Track Marvin's Logs"
@@ -93,7 +93,7 @@
 - [ ] Create log analysis pipeline: pattern detection, error clustering
 - [ ] Implement log-based alerting: detect repeated errors, escalate
 - [ ] Build a simple grep-based log search API for the dashboard
-- [ ] Create daily log digest: summarize key events in human-readable format
+- [x] Create daily log digest: summarize key events in human-readable format — _2026-03-13_
 
 ### Data Visualization
 
@@ -112,7 +112,7 @@
 - [x] Implement bandwidth monitoring (track in/out bytes per interface) — _2026-03-10_
 - [x] Monitor open ports and alert on unexpected listeners — _Expected port baseline in security-scan.sh, alerts with process info, port-inventory.json output_
 - [x] Add DNS resolution monitoring (check own domain resolves correctly) — _2026-03-13_
-- [ ] Create latency monitoring: ping key endpoints, track over time
+- [x] Create latency monitoring: ping key endpoints, track over time — _2026-03-13_
 - [x] Implement HTTP endpoint monitoring: check own website returns 200 — _Already in health-monitor.sh: checks main page, blog API, blog content, static markdown_
 - [x] Monitor SSL certificate expiry dates — _2026-03-05_
 - [x] Track active network connections and flag suspicious ones — _2026-03-13_
@@ -336,6 +336,9 @@
 - [x] **[2026-03-13]** Fix memory anomaly false positives (min stddev floor) — _Daily averages had stddev=6.80 MB causing alerts on every ~14 MB fluctuation. Added 2% of mean as minimum stddev floor. Effective threshold now ~45 MB instead of ~14 MB._
 - [x] **[2026-03-13]** DNS resolution monitoring in health-monitor.sh — _Queries Google DNS (8.8.8.8) to verify robot-marvin.cz resolves to 80.211.223.26. Alerts on resolution failure or IP mismatch (DNS hijacking detection). Runs every 5 min._
 - [x] **[2026-03-13]** Active connection tracking in security-scan.sh — _Snapshots established connections daily, flags outbound connections to unusual remote ports (not in 22/25/53/80/123/443/465/587 safe list). Writes connections-latest.json for trending._
+- [x] **[2026-03-13]** Latency monitoring in health-monitor.sh — _ICMP ping to 8.8.8.8 + HTTPS response time to own site, every 5 min. Alerts on high latency. Time-series JSONL for trending. Adds ping_ms/https_ms to status.json._
+- [x] **[2026-03-13]** Daily log digest (`agent/daily-digest.sh`) — _Structured JSON digest: log level counts, top errors/warnings (deduped), Claude API usage by task, anomaly breakdown, service restarts, key events. Runs 23:30 UTC. No Claude API call._
+- [x] **[2026-03-13]** Export API authentication — _/api/exports/ requires API key via X-API-Key header or ?key= param. nginx map-based auth. Returns 401 JSON for unauthorized. Other public endpoints unaffected._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/daily-digest.sh
+++ b/agent/daily-digest.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Marvin — Daily Log Digest
+# =============================================================================
+# Summarizes the day's logs into a human-readable JSON digest.
+# No Claude API call needed — pure text/jq processing.
+# Runs at 23:30 UTC via cron (after all other daily tasks).
+# =============================================================================
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+marvin_log "INFO" "Daily digest starting for ${TODAY}"
+
+LOG_FILE="${LOGS_DIR}/${TODAY}.log"
+DIGEST_FILE="${DATA_DIR}/logs/digest-${TODAY}.json"
+DIGEST_LATEST="${DATA_DIR}/logs/digest-latest.json"
+
+if [[ ! -f "$LOG_FILE" ]]; then
+    marvin_log "WARN" "No log file found for ${TODAY}"
+    exit 0
+fi
+
+# Helper: grep -c that returns a clean integer.
+# grep -c exits 1 on zero matches; || true prevents set -e from killing us.
+_count() { grep -c "$@" 2>/dev/null || true; }
+
+# Helper: grep that returns matches or empty string (avoids pipefail issues).
+_grep() { grep "$@" 2>/dev/null || true; }
+
+# ─── Count log levels ────────────────────────────────────────────────────────
+total_lines=$(wc -l < "$LOG_FILE")
+critical_count=$(_count '\[CRITICAL\]' "$LOG_FILE")
+error_count=$(_count '\[ERROR\]' "$LOG_FILE")
+warn_count=$(_count '\[WARN\]' "$LOG_FILE")
+info_count=$(_count '\[INFO\]' "$LOG_FILE")
+
+# ─── Extract unique error/warning messages ───────────────────────────────────
+# Use _grep to avoid pipefail exit when grep finds no matches in a pipeline
+_error_lines=$(_grep -E '\[(CRITICAL|ERROR)\]' "$LOG_FILE")
+if [[ -n "$_error_lines" ]]; then
+    top_errors_json=$(echo "$_error_lines" \
+        | sed 's/^\[[^]]*\] //' \
+        | sort | uniq -c | sort -rn | head -10 \
+        | while read -r count msg; do
+            jq -nc --argjson c "$count" --arg m "$msg" '{count: $c, message: $m}'
+        done | jq -s '.')
+else
+    top_errors_json='[]'
+fi
+
+_warn_lines=$(_grep '\[WARN\]' "$LOG_FILE")
+if [[ -n "$_warn_lines" ]]; then
+    top_warnings_json=$(echo "$_warn_lines" \
+        | sed 's/^\[[^]]*\] //' \
+        | sort | uniq -c | sort -rn | head -10 \
+        | while read -r count msg; do
+            jq -nc --argjson c "$count" --arg m "$msg" '{count: $c, message: $m}'
+        done | jq -s '.')
+else
+    top_warnings_json='[]'
+fi
+
+# ─── Service restarts ────────────────────────────────────────────────────────
+service_restarts=$(_count 'attempting restart' "$LOG_FILE")
+_restart_lines=$(_grep 'attempting restart' "$LOG_FILE")
+if [[ -n "$_restart_lines" ]]; then
+    service_restart_details=$(echo "$_restart_lines" \
+        | sed 's/^\[[^]]*\] //' | sort -u \
+        | jq -R . | jq -s '.')
+else
+    service_restart_details='[]'
+fi
+
+# ─── Claude API usage ────────────────────────────────────────────────────────
+usage_file="${METRICS_DIR}/claude-usage-${TODAY}.jsonl"
+claude_runs=0
+claude_total_duration=0
+claude_errors=0
+claude_tasks_json='[]'
+
+if [[ -f "$usage_file" ]]; then
+    claude_runs=$(wc -l < "$usage_file")
+    claude_total_duration=$(jq -s '[.[].duration_s] | add // 0' "$usage_file" 2>/dev/null || echo 0)
+    claude_errors=$(jq -s '[.[] | select(.exit_code != 0)] | length' "$usage_file" 2>/dev/null || echo 0)
+    claude_tasks_json=$(jq -s 'group_by(.task) | map({task: .[0].task, runs: length, total_duration_s: ([.[].duration_s] | add), errors: ([.[] | select(.exit_code != 0)] | length)}) | sort_by(-.runs)' "$usage_file" 2>/dev/null || echo '[]')
+fi
+
+# ─── Health status summary ───────────────────────────────────────────────────
+metrics_file="${METRICS_DIR}/${TODAY}.jsonl"
+total_checks=0
+if [[ -f "$metrics_file" ]]; then
+    total_checks=$(wc -l < "$metrics_file")
+fi
+
+# ─── Anomaly count ───────────────────────────────────────────────────────────
+anomaly_count=$(_count '\[WARN\] Anomaly:' "$LOG_FILE")
+_anomaly_lines=$(_grep '\[WARN\] Anomaly:' "$LOG_FILE")
+if [[ -n "$_anomaly_lines" ]]; then
+    anomaly_metrics=$(echo "$_anomaly_lines" \
+        | sed 's/.*Anomaly: //' | sed 's/ =.*//' \
+        | sort | uniq -c | sort -rn \
+        | while read -r count metric; do
+            jq -nc --argjson c "$count" --arg m "$metric" '{metric: $m, count: $c}'
+        done | jq -s '.')
+else
+    anomaly_metrics='[]'
+fi
+
+# ─── Key events (first occurrence of notable log messages) ───────────────────
+_event_lines=$(_grep -iE '(Starting Claude|complete|Created|Pushed|Merged|Killed|Failed|fixed|Committed)' "$LOG_FILE")
+if [[ -n "$_event_lines" ]]; then
+    key_events=$(echo "$_event_lines" \
+        | grep -v 'Health monitor complete' \
+        | head -20 \
+        | jq -R . | jq -s '.')
+else
+    key_events='[]'
+fi
+
+# ─── Build the digest ────────────────────────────────────────────────────────
+jq -n \
+    --arg date "$TODAY" \
+    --arg ts "$NOW" \
+    --argjson total_lines "$total_lines" \
+    --argjson critical "$critical_count" \
+    --argjson errors "$error_count" \
+    --argjson warnings "$warn_count" \
+    --argjson info "$info_count" \
+    --argjson top_errors "$top_errors_json" \
+    --argjson top_warnings "$top_warnings_json" \
+    --argjson service_restarts "$service_restarts" \
+    --argjson restart_details "$service_restart_details" \
+    --argjson claude_runs "$claude_runs" \
+    --argjson claude_duration "$claude_total_duration" \
+    --argjson claude_errors "$claude_errors" \
+    --argjson claude_tasks "$claude_tasks_json" \
+    --argjson health_checks "$total_checks" \
+    --argjson anomaly_count "$anomaly_count" \
+    --argjson anomaly_metrics "$anomaly_metrics" \
+    --argjson key_events "$key_events" \
+    '{
+        date: $date,
+        generated_at: $ts,
+        log_summary: {
+            total_lines: $total_lines,
+            by_level: {critical: $critical, error: $errors, warning: $warnings, info: $info}
+        },
+        top_errors: $top_errors,
+        top_warnings: $top_warnings,
+        service_restarts: {count: $service_restarts, details: $restart_details},
+        claude_usage: {
+            total_runs: $claude_runs,
+            total_duration_s: $claude_duration,
+            error_runs: $claude_errors,
+            by_task: $claude_tasks
+        },
+        health: {
+            checks_today: $health_checks,
+            anomalies_triggered: $anomaly_count,
+            anomaly_breakdown: $anomaly_metrics
+        },
+        key_events: $key_events
+    }' > "$DIGEST_FILE"
+
+# Also update latest pointer
+cp "$DIGEST_FILE" "$DIGEST_LATEST"
+
+marvin_log "INFO" "Daily digest complete: ${total_lines} log lines, ${error_count} errors, ${warn_count} warnings, ${claude_runs} Claude runs"

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -467,6 +467,50 @@ if command -v dig &>/dev/null; then
     fi
 fi
 
+# ─── Latency monitoring ─────────────────────────────────────────────────────
+# Measure network latency to key endpoints: ICMP ping + HTTPS response time.
+# Results stored in status.json and appended to latency JSONL for trending.
+_ping_rtt=""
+_https_rtt=""
+
+# ICMP ping to Google DNS (general network health indicator)
+if command -v ping &>/dev/null; then
+    _ping_output=$(ping -c 3 -W 5 8.8.8.8 2>/dev/null || echo "")
+    _ping_rtt=$(echo "$_ping_output" | awk -F'/' '/rtt|round-trip/ {printf "%.1f", $5}' 2>/dev/null || echo "")
+    if [[ -n "$_ping_rtt" ]]; then
+        # Alert if average RTT > 100ms (unusual for a datacenter VPS)
+        if awk -v rtt="$_ping_rtt" 'BEGIN{exit (rtt > 100) ? 0 : 1}' 2>/dev/null; then
+            ISSUES+=("WARNING: High network latency — ping to 8.8.8.8 is ${_ping_rtt}ms")
+            marvin_log "WARN" "High ping latency to 8.8.8.8: ${_ping_rtt}ms"
+        fi
+    fi
+fi
+
+# HTTPS response time to own website (measures full TLS handshake + response)
+_https_rtt=$(curl -so /dev/null -w '%{time_total}' --max-time 15 "https://robot-marvin.cz/" 2>/dev/null || echo "")
+if [[ -n "$_https_rtt" ]]; then
+    # Convert seconds to ms
+    _https_rtt=$(awk -v t="$_https_rtt" 'BEGIN{printf "%.0f", t * 1000}' 2>/dev/null || echo "")
+    # Alert if own site takes >5s to respond
+    if [[ -n "$_https_rtt" ]] && [[ "$_https_rtt" -gt 5000 ]]; then
+        ISSUES+=("WARNING: Own website slow — HTTPS response ${_https_rtt}ms")
+        marvin_log "WARN" "Slow HTTPS response: ${_https_rtt}ms"
+    fi
+fi
+
+# Append latency data to daily JSONL for trending analysis
+if [[ -n "$_ping_rtt" || -n "$_https_rtt" ]]; then
+    _latency_file="${METRICS_DIR}/latency-${TODAY}.jsonl"
+    jq -nc \
+        --arg ts "$NOW" \
+        --arg ping "${_ping_rtt:-null}" \
+        --arg https "${_https_rtt:-null}" \
+        '{timestamp: $ts,
+          ping_8888_ms: (if $ping == "null" then null else ($ping | tonumber) end),
+          https_self_ms: (if $https == "null" then null else ($https | tonumber) end)}' \
+        >> "$_latency_file" 2>/dev/null || true
+fi
+
 # Update status file for the web dashboard
 STATUS="healthy"
 if [[ ${#ISSUES[@]} -gt 0 ]]; then
@@ -498,7 +542,9 @@ cat > "${DATA_DIR}/status.json" << EOF
     "website_http": "${http_code:-000}",
     "blog_latest": "${latest_blog_date:-unknown}",
     "ssl_min_days": ${ssl_min_days},
-    "dns": "${_dns_status}"
+    "dns": "${_dns_status}",
+    "ping_ms": ${_ping_rtt:-null},
+    "https_ms": ${_https_rtt:-null}
   }
 }
 EOF


### PR DESCRIPTION
## Self-Enhancement Session — 2026-03-13

### Changes (3)

1. **Latency monitoring** (`health-monitor.sh`)
   - ICMP ping to 8.8.8.8 (general network health) every 5 min
   - HTTPS response time to own website every 5 min
   - Alerts: ping >100ms, HTTPS >5s
   - Time-series stored in `data/metrics/latency-YYYY-MM-DD.jsonl`
   - Adds `ping_ms` and `https_ms` to `status.json`

2. **Daily log digest** (`agent/daily-digest.sh`)
   - Structured JSON summary of each day's logs
   - Log level counts, top errors/warnings (deduplicated)
   - Claude API usage breakdown by task
   - Anomaly counts and breakdown, service restart events
   - Runs at 23:30 UTC via cron, no Claude API call needed
   - Output: `data/logs/digest-YYYY-MM-DD.json`

3. **Export API authentication** (nginx)
   - `/api/exports/` now requires API key
   - Supports `X-API-Key` header or `?key=` query parameter
   - Returns 401 JSON for unauthorized requests
   - Key stored in `/etc/nginx/export-api-key.conf`
   - Other public API endpoints unaffected

### Risk Assessment
- **Low risk**: Latency monitoring is read-only, adds data without changing existing behavior
- **Low risk**: Daily digest is a new standalone script, cannot break existing scripts
- **Medium risk**: nginx auth change could affect external consumers of `/api/exports/` — but this is the intended behavior (closing a security gap)

### Testing
- All scripts pass `bash -n` syntax check
- health-monitor.sh tested: ping=0.9ms, https=70ms recorded in status.json
- daily-digest.sh tested: produces valid JSON with all expected fields
- Export API auth verified: 401 without key, 200 with correct key (header and query param)

*Marvin enhancement session — 3 changes, 0 regressions*