### PR TITLE
fix: #180 Warning: negotiate-handler — source_ip embedded in prompt wi

### DIFF
--- a/agent/negotiate-handler.sh
+++ b/agent/negotiate-handler.sh
@@ -84,7 +84,7 @@ while IFS= read -r request_file; do
     fi
 
     # Extract source IP for rate limiting
-    source_ip=$(echo "$sanitized_json" | jq -r '.source_ip // .ip // .from // "unknown"')
+    source_ip=$(echo "$sanitized_json" | jq -r '.source_ip // .ip // .from // "unknown"' | tr -d '\n\r' | tr -dc '[:print:]' | head -c 45)
 
     # Rate limit check
     ip_count=$(echo "$rate_limits" | jq -r --arg ip "$source_ip" '.[$ip].count // 0')


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #180 — Warning: negotiate-handler — source_ip embedded in prompt without newline sanitization (partial prompt injection vector)

**Fix:** Added newline/control character stripping and length truncation to source_ip after jq -r extraction, preventing newline injection into the Claude prompt on line 150.

### Changed Files
```
agent/negotiate-handler.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #180*