### PR TITLE
fix: #38 Warning: Process whitelist in health-monitor.sh can be bypass

### DIFF
--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -265,13 +265,17 @@ while IFS= read -r line; do
     proc_cpu=$(echo "$line" | awk '{print $2}')
     proc_name=$(echo "$line" | awk '{print $3}')
 
-    # Skip known-good processes that are part of monitoring infrastructure
-    # claude: our AI engine, apt/dpkg: package management, ps/jq: monitoring tools,
-    # fail2ban: checked by this script (would flag itself)
-    # Note: curl, git, node are NOT excluded — the 10-minute tracking window
-    # handles their transient spikes while still catching genuinely stuck processes
+    # Skip known-good processes — verify full exe path to prevent
+    # comm field spoofing via prctl(PR_SET_NAME) (#38)
+    proc_exe=$(readlink -f "/proc/${proc_pid}/exe" 2>/dev/null || echo "")
     case "$proc_name" in
-        claude|apt*|dpkg*|ps|jq|fail2ban*) continue ;;
+        claude|apt*|dpkg*|ps|jq|fail2ban*)
+            if [[ "$proc_exe" == /usr/bin/* || "$proc_exe" == /usr/sbin/* || \
+                  "$proc_exe" == /usr/local/bin/* || "$proc_exe" == /snap/* ]]; then
+                continue
+            fi
+            marvin_log "WARN" "Untrusted exe for allowlisted name: ${proc_name} (PID ${proc_pid}, exe=${proc_exe:-unknown}) at ${proc_cpu}% CPU"
+        ;;
     esac
 
     # Check if this PID was already flagged


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #38 — Warning: Process whitelist in health-monitor.sh can be bypassed via comm field spoofing

**Fix:** The runaway process killer now verifies the full executable path via `/proc/$pid/exe` (readlink) before trusting the `comm` field allowlist. A process that spoofs its name via `prctl(PR_SET_NAME)` but has its binary outside trusted system directories (`/usr/bin`, `/usr/sbin`, `/usr/local/bin`, `/snap`) will no longer be skipped — instead it logs a WARN and proceeds with runaway detection.

### Changed Files
```
agent/health-monitor.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #38*