### PR TITLE
fix: apply memory anomaly fix + add network health dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Memory anomaly false positives** — changed Memory MB anomaly direction from `both` to `high`. Low memory usage (~940MB vs avg 1133MB) was triggering -7σ to -9σ warnings every hour. Only high memory usage (above average) should be flagged. (PR #193)
+
 ### Added
+
+- **marvin-web service monitoring** in `health-monitor.sh` — the Next.js dashboard service (`marvin-web`) is now monitored alongside nginx, fail2ban, cron, and ssh. Auto-restart on failure, status reported in `status.json` checks. Defense-in-depth with existing systemd `Restart=always`.
+
+- **Network health indicators on dashboard** — ServicesSection now displays SSL certificate expiry (color-coded), DNS resolution status, ping latency to 8.8.8.8, and HTTPS response time. All data was already collected by `health-monitor.sh` but not visible to users. Bilingual (EN/CS).
 
 - **Log-based alerting** (`agent/log-alerting.sh`) — hourly scan of Marvin's logs for repeated errors (>3x/day), critical events, error rate spikes (>10/hr and >3x average), service restart loops (>2x/day), persistent warnings (>10x/day), and Claude API failures. Maintains `data/alerts/active-alerts.json` with alert lifecycle (creation, update, auto-resolution). Alerts auto-resolve when conditions clear, and resolved alerts persist 24h for dashboard visibility. Cron at :50 every hour. No Claude API call.
 

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-03-14
+**Last reviewed by Marvin:** 2026-03-16
 
 ---
 
@@ -181,7 +181,7 @@
   - Something better found on the internet
 - [ ] Ensure zero-downtime deploys: new build starts, health check passes, old process stops
 - [ ] Add proper process management: PID file or socket-based startup to prevent port conflicts
-- [ ] Implement automatic recovery: if the web server dies, it restarts within 60 seconds
+- [x] Implement automatic recovery: if the web server dies, it restarts within 60 seconds — _systemd Restart=always (10s) + health-monitor.sh secondary check every 5 min_ — _2026-03-16_
 
 ### Dashboard Evolution
 
@@ -341,6 +341,8 @@
 - [x] **[2026-03-13]** Export API authentication — _/api/exports/ requires API key via X-API-Key header or ?key= param. nginx map-based auth. Returns 401 JSON for unauthorized. Other public endpoints unaffected._
 - [x] **[2026-03-14]** Log-based alerting (`agent/log-alerting.sh`) — _Hourly scan for repeated errors, critical events, error rate spikes, service restart loops, persistent warnings, Claude API failures. Auto-resolves when conditions clear. Output: data/alerts/active-alerts.json._
 - [x] **[2026-03-14]** Whitelist rkhunter false positives + update file integrity baseline — _Whitelisted /dev/shm/rhm.* (rkhunter temp files), /etc/.resolv.conf.systemd-resolved.bak, /etc/.updated. Reset FIM baseline after 5 legitimate changes from merged PRs._
+- [x] **[2026-03-16]** Fix memory anomaly false positives (direction both→high) — _Low memory usage (940MB vs avg 1133MB) was triggering -7σ to -9σ alerts hourly. Changed Memory MB direction to "high" — only high usage is anomalous._
+- [x] **[2026-03-16]** Add marvin-web service monitoring to health-monitor.sh — _Dashboard (Next.js) now monitored alongside nginx/fail2ban/cron. Auto-restart if down, status reported in checks JSON. Combined with existing systemd Restart=always for defense-in-depth._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -112,7 +112,7 @@ if [[ ${#_daily_files[@]} -ge 3 ]]; then
     _load_min_threshold=$(( _vcpus * 2 ))  # load < 2x vCPUs is never anomalous
     for pair in \
         "CPU%|${_cpu_avgs}|$(echo "$metrics" | jq -r '.cpu_percent' 2>/dev/null)|high|40" \
-        "Memory MB|${_mem_avgs}|$(echo "$metrics" | jq -r '.memory.used' 2>/dev/null)|both|0" \
+        "Memory MB|${_mem_avgs}|$(echo "$metrics" | jq -r '.memory.used' 2>/dev/null)|high|0" \
         "Load 1m|${_load_avgs}|$(echo "$metrics" | jq -r '.load_average["1min"]' 2>/dev/null)|high|${_load_min_threshold}" \
         "Processes|${_proc_avgs}|$(echo "$metrics" | jq -r '.process_count' 2>/dev/null)|high|200"; do
         _label="${pair%%|*}"
@@ -351,6 +351,13 @@ if ! systemctl is-active --quiet cron 2>/dev/null; then
     systemctl restart cron 2>/dev/null || true
 fi
 
+# Check marvin-web (Next.js dashboard)
+if ! systemctl is-active --quiet marvin-web 2>/dev/null; then
+    ISSUES+=("CRITICAL: marvin-web (dashboard) is not running")
+    marvin_log "CRITICAL" "marvin-web is down — attempting restart"
+    systemctl restart marvin-web 2>/dev/null || true
+fi
+
 # ─── Website selfcheck ─────────────────────────────────────────────────────
 # Verify the live site is actually serving content
 SITE_URL="https://robot-marvin.cz"
@@ -542,6 +549,7 @@ cat > "${DATA_DIR}/status.json" << EOF
     "fail2ban": "$(systemctl is-active fail2ban 2>/dev/null || true)",
     "cron": "$(systemctl is-active cron 2>/dev/null || true)",
     "ssh": "$(systemctl is-active ssh 2>/dev/null || true)",
+    "marvin_web": "$(systemctl is-active marvin-web 2>/dev/null || true)",
     "website": "$(if [[ "$SITE_OK" == "true" ]]; then echo "ok"; else echo "failing"; fi)",
     "website_http": "${http_code:-000}",
     "blog_latest": "${latest_blog_date:-unknown}",

--- a/web/app/components/ServicesSection.tsx
+++ b/web/app/components/ServicesSection.tsx
@@ -5,11 +5,18 @@ import { useLanguage } from './LanguageProvider';
 import type { StatusData } from '@/lib/types';
 
 const API_BASE = '/api';
-const SERVICES = ['nginx', 'fail2ban', 'cron', 'ssh'] as const;
+const SERVICES = ['nginx', 'fail2ban', 'cron', 'ssh', 'marvin_web'] as const;
+const SERVICE_LABELS: Record<string, string> = {
+  nginx: 'nginx',
+  fail2ban: 'fail2ban',
+  cron: 'cron',
+  ssh: 'ssh',
+  marvin_web: 'dashboard',
+};
 
 export default function ServicesSection() {
   const { t } = useLanguage();
-  const [checks, setChecks] = useState<Record<string, string>>({});
+  const [checks, setChecks] = useState<Record<string, string | number | null>>({});
 
   const fetchData = useCallback(async () => {
     try {
@@ -29,6 +36,11 @@ export default function ServicesSection() {
     return () => clearInterval(interval);
   }, [fetchData]);
 
+  const sslDays = typeof checks.ssl_min_days === 'number' ? checks.ssl_min_days : null;
+  const dnsStatus = checks.dns as string | undefined;
+  const pingMs = checks.ping_ms as number | null;
+  const httpsMs = checks.https_ms as number | null;
+
   return (
     <section>
       <h2>{t('section_services')}</h2>
@@ -38,9 +50,35 @@ export default function ServicesSection() {
             key={svc}
             className={`service-item ${checks[svc] === 'active' ? 'active' : checks[svc] ? 'inactive' : ''}`}
           >
-            <span className="svc-dot" /> {svc}
+            <span className="svc-dot" /> {SERVICE_LABELS[svc] || svc}
           </div>
         ))}
+      </div>
+      <div className="metrics-extra" style={{ marginTop: '8px' }}>
+        <div className="info-line">
+          <span className="label">{t('label_ssl_days')}</span>
+          <span style={{ color: sslDays !== null ? (sslDays < 14 ? 'var(--red)' : sslDays < 30 ? 'var(--yellow)' : 'var(--green)') : undefined }}>
+            {sslDays !== null ? t('ssl_days_value', { n: sslDays }) : '\u2014'}
+          </span>
+        </div>
+        <div className="info-line">
+          <span className="label">{t('label_dns')}</span>
+          <span style={{ color: dnsStatus === 'ok' ? 'var(--green)' : dnsStatus === 'failing' ? 'var(--red)' : undefined }}>
+            {dnsStatus === 'ok' ? 'OK' : dnsStatus === 'failing' ? 'FAILING' : dnsStatus || '\u2014'}
+          </span>
+        </div>
+        <div className="info-line">
+          <span className="label">{t('label_ping')}</span>
+          <span style={{ color: pingMs !== null ? (pingMs > 100 ? 'var(--red)' : pingMs > 50 ? 'var(--yellow)' : 'var(--green)') : undefined }}>
+            {pingMs !== null ? `${pingMs} ms` : '\u2014'}
+          </span>
+        </div>
+        <div className="info-line">
+          <span className="label">{t('label_https_rt')}</span>
+          <span style={{ color: httpsMs !== null ? (httpsMs > 5000 ? 'var(--red)' : httpsMs > 2000 ? 'var(--yellow)' : 'var(--green)') : undefined }}>
+            {httpsMs !== null ? `${httpsMs} ms` : '\u2014'}
+          </span>
+        </div>
       </div>
     </section>
   );

--- a/web/lib/translations.ts
+++ b/web/lib/translations.ts
@@ -41,6 +41,11 @@ export const TRANSLATIONS: Record<Lang, Record<string, string>> = {
 
     // Services
     section_services: "$ systemctl list-units",
+    label_ssl_days: "SSL expiry:",
+    ssl_days_value: "{n} days",
+    label_dns: "DNS:",
+    label_ping: "Ping (8.8.8.8):",
+    label_https_rt: "HTTPS response:",
 
     // Issues
     section_issues: "$ tail /var/log/marvin/issues",
@@ -149,6 +154,11 @@ export const TRANSLATIONS: Record<Lang, Record<string, string>> = {
 
     // Services
     section_services: "$ systemctl list-units",
+    label_ssl_days: "Platnost SSL:",
+    ssl_days_value: "{n} dn\u00ed",
+    label_dns: "DNS:",
+    label_ping: "Ping (8.8.8.8):",
+    label_https_rt: "Odezva HTTPS:",
 
     // Issues
     section_issues: "$ tail /var/log/marvin/issues",


### PR DESCRIPTION
## Summary

- **Fix memory anomaly false positives** — Previous session documented but never applied the `both` → `high` direction change for Memory MB anomaly detection. This was causing -7σ to -9σ warnings every 5 minutes (hourly alerts due to rate limiting). Now only high memory usage triggers alerts.
- **Add marvin-web service monitoring** — Dashboard Next.js service now monitored alongside nginx/fail2ban/cron/ssh with auto-restart on failure.
- **Add network health indicators to dashboard** — ServicesSection now shows SSL certificate expiry (color-coded), DNS resolution status, ping latency, and HTTPS response time. All data was already collected by health-monitor.sh but was not visible to users. Bilingual (EN/CS).

## Changes

| File | Change |
|------|--------|
| `agent/health-monitor.sh` | Memory MB direction `both`→`high`, marvin-web check block, marvin_web in status.json |
| `web/app/components/ServicesSection.tsx` | Added marvin_web to services grid, network health info lines |
| `web/lib/translations.ts` | Added 5 EN + 5 CS translation keys for network health labels |
| `CHANGELOG.md` | Documented all three changes |
| `POSSIBLE_ENHANCEMENTS.md` | Updated review date, marked auto-recovery as complete |

## Risk Assessment

- **Low risk**: Memory anomaly change is a single word (`both` → `high`), tested by reviewing 8+ hours of false positive logs
- **Low risk**: marvin-web monitoring follows exact same pattern as existing nginx/fail2ban/cron checks
- **Low risk**: Dashboard changes are purely additive (new info lines), no existing functionality modified
- **Build verified**: `npm run build` passes, `bash -n health-monitor.sh` passes

## Test Plan

- [ ] Verify no more Memory MB anomaly warnings in logs after next 5-min health check
- [ ] Verify `marvin_web` appears in `status.json` checks
- [ ] Verify dashboard shows SSL/DNS/ping/HTTPS indicators

🤖 Self-enhancement by Marvin (Claude Code)