### PR TITLE
fix: #189 Warning: claude binary path may not match trusted dirs in he

### DIFF
--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -259,6 +259,11 @@ fi
 RUNAWAY_FILE="${DATA_DIR}/runaway-procs.json"
 [[ -f "$RUNAWAY_FILE" ]] || echo '{}' > "$RUNAWAY_FILE"
 
+# Resolve trusted paths for claude CLI — it's installed via npm and the
+# node binary may live outside /usr/bin on some setups (nvm, .npm-global) (#189)
+_trusted_node_bin=$(readlink -f "$(command -v node 2>/dev/null)" 2>/dev/null || echo "")
+_trusted_claude_bin=$(readlink -f "$(command -v claude 2>/dev/null)" 2>/dev/null || echo "")
+
 while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     proc_pid=$(echo "$line" | awk '{print $1}')
@@ -271,7 +276,9 @@ while IFS= read -r line; do
     case "$proc_name" in
         claude|apt*|dpkg*|ps|jq|fail2ban*)
             if [[ "$proc_exe" == /usr/bin/* || "$proc_exe" == /usr/sbin/* || \
-                  "$proc_exe" == /usr/local/bin/* || "$proc_exe" == /snap/* ]]; then
+                  "$proc_exe" == /usr/local/bin/* || "$proc_exe" == /snap/* || \
+                  ( -n "$_trusted_node_bin" && "$proc_exe" == "$_trusted_node_bin" ) || \
+                  ( -n "$_trusted_claude_bin" && "$proc_exe" == "$_trusted_claude_bin" ) ]]; then
                 continue
             fi
             marvin_log "WARN" "Untrusted exe for allowlisted name: ${proc_name} (PID ${proc_pid}, exe=${proc_exe:-unknown}) at ${proc_cpu}% CPU"


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #189 — Warning: claude binary path may not match trusted dirs in health-monitor.sh whitelist

**Fix:** Added dynamic resolution of the actual node and claude binary paths at runtime, so the runaway process killer correctly skips legitimate claude processes even when node/claude are installed via npm in non-standard locations (e.g. nvm, .npm-global).

### Changed Files
```
agent/health-monitor.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #189*