### PR TITLE
fix: detect and auto-heal Next.js build/server mismatch

### DIFF
--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -427,6 +427,25 @@ if [[ -n "${latest_evening_md:-}" ]]; then
     fi
 fi
 
+# Check 5: Next.js JS asset integrity (detects build/server mismatch)
+# The running server may have an old build ID while disk has a newer build —
+# causing the HTML to reference JS chunks that no longer exist (all 404).
+# This is invisible to HTTP 200 checks but breaks the entire dashboard.
+_js_chunk=$(curl -s --max-time 10 "${SITE_URL}/" 2>/dev/null \
+    | grep -oP 'src="/_next/static/chunks/[^"]*"' | head -1 \
+    | grep -oP '/_next/static/chunks/[^"]*')
+if [[ -n "$_js_chunk" ]]; then
+    _chunk_status=$(curl -so /dev/null -w '%{http_code}' --max-time 10 "${SITE_URL}${_js_chunk}" 2>/dev/null || echo "000")
+    if [[ "$_chunk_status" != "200" ]]; then
+        ISSUES+=("CRITICAL: JS asset ${_js_chunk} returned HTTP ${_chunk_status} — build mismatch, restarting marvin-web")
+        marvin_log "CRITICAL" "JS asset ${_js_chunk} returned HTTP ${_chunk_status} — build/server mismatch detected, restarting marvin-web"
+        systemctl restart marvin-web 2>/dev/null || true
+        SITE_OK=false
+    fi
+else
+    marvin_log "WARN" "Could not extract JS chunk URL from page to verify asset integrity"
+fi
+
 # ─── SSL certificate expiry checks ──────────────────────────────────────────
 # Check TLS certificates for web and email services, warn if <14 days to expiry
 


### PR DESCRIPTION
## Problem

The dashboard appeared healthy (HTTP 200, page contained \"Marvin\") but all JavaScript assets were returning **404**, leaving every metric and blog post permanently stuck on \"Loading\" / dashes.

**Root cause:** When `self-enhance.sh` rebuilds the Next.js app, it generates new JS chunk filenames (hashed by content). But `marvin-web.service` keeps running the old build — so the HTML it serves references old chunk names that no longer exist on disk. The existing website checks (`website_http: 200`, `website: ok`) couldn't catch this because the HTML shell renders fine; it's the client-side JS that silently fails.

This was discovered and manually fixed today (Mar 17) by restarting marvin-web. This PR prevents it from happening again.

## Fix

Add **Check 5** to `health-monitor.sh` (runs every 5 minutes):

1. Fetch the live page and extract a JS chunk URL from it
2. Request that URL and check the HTTP status
3. If it returns anything other than 200 → CRITICAL issue + automatic `systemctl restart marvin-web`

## Test plan

- [ ] Verify `health-monitor.sh` passes `bash -n` (syntax check)
- [ ] Confirm check 5 runs without error when assets are healthy (200)
- [ ] After the next rebuild by `self-enhance.sh`, confirm the service auto-restarts within 5 minutes instead of staying broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)