### PR TITLE
fix: prevent health-monitor early abort on missing JS chunks

### DIFF
--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -433,7 +433,7 @@ fi
 # This is invisible to HTTP 200 checks but breaks the entire dashboard.
 _js_chunk=$(curl -s --max-time 10 "${SITE_URL}/" 2>/dev/null \
     | grep -oP 'src="/_next/static/chunks/[^"]*"' | head -1 \
-    | grep -oP '/_next/static/chunks/[^"]*')
+    | grep -oP '/_next/static/chunks/[^"]*' || true)
 if [[ -n "$_js_chunk" ]]; then
     _chunk_status=$(curl -so /dev/null -w '%{http_code}' --max-time 10 "${SITE_URL}${_js_chunk}" 2>/dev/null || echo "000")
     if [[ "$_chunk_status" != "200" ]]; then


### PR DESCRIPTION
## Summary

- Adds `|| true` to the grep pipeline in Check 5 (JS asset integrity check) of `health-monitor.sh`
- Without this, when the page has no JS chunk references (mid-rebuild, structure change, or downtime), `grep` returns exit code 1, which triggers `set -euo pipefail` and aborts the entire health monitor
- The existing `[[ -n "$_js_chunk" ]]` guard already handles empty results correctly — this fix just ensures we reach it

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)