### PR TITLE
fix: #218 bug: health-monitor.sh may abort early if page has no JS chu

### DIFF
--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -433,7 +433,7 @@ fi
 # This is invisible to HTTP 200 checks but breaks the entire dashboard.
 _js_chunk=$(curl -s --max-time 10 "${SITE_URL}/" 2>/dev/null \
     | grep -oP 'src="/_next/static/chunks/[^"]*"' | head -1 \
-    | grep -oP '/_next/static/chunks/[^"]*')
+    | grep -oP '/_next/static/chunks/[^"]*' || true)
 if [[ -n "$_js_chunk" ]]; then
     _chunk_status=$(curl -so /dev/null -w '%{http_code}' --max-time 10 "${SITE_URL}${_js_chunk}" 2>/dev/null || echo "000")
     if [[ "$_chunk_status" != "200" ]]; then


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #218 — bug: health-monitor.sh may abort early if page has no JS chunks (set -euo pipefail + grep no-match)

**Fix:** Added `|| true` to the JS chunk extraction pipeline so that a grep no-match (exit 1) is treated as an empty result instead of aborting the script under set -euo pipefail, preventing silent skipping of subsequent health checks like SSL expiry.

### Changed Files
```
agent/health-monitor.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #218*