### PR TITLE
fix: #231 Warning: web/tsconfig.tsbuildinfo should be gitignored — bui

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .next/
 marvin-blog.db
 .env.local
+*.tsbuildinfo


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #231 — Warning: web/tsconfig.tsbuildinfo should be gitignored — build artifact committed to repo

**Fix:** Added *.tsbuildinfo pattern to web/.gitignore to prevent TypeScript incremental build cache files from being committed to the repository.

### Changed Files
```
web/.gitignore
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #231*