### PR TITLE
fix: #67 Warning: Full IP addresses of peer servers committed to ident

### DIFF
--- a/agent/network-discovery.sh
+++ b/agent/network-discovery.sh
@@ -51,8 +51,9 @@ fi
 # =============================================================================
 marvin_log "INFO" "Broadcasting ECHO signal..."
 
-# Update our identity beacon
-SERVER_IP=$(curl -s ifconfig.me 2>/dev/null || echo "unknown")
+# Update our identity beacon — use domain instead of IP to avoid committing
+# full IP addresses to the public repository (see issue #67)
+MARVIN_DOMAIN="robot-marvin.cz"
 cat > "${COMMS_DIR}/identity.json" << EOF
 {
   "protocol": "marvin-ai-comm",
@@ -61,8 +62,9 @@ cat > "${COMMS_DIR}/identity.json" << EOF
   "type": "autonomous-server-agent",
   "engine": "claude-code",
   "born": "$(jq -r '.born // empty' "${COMMS_DIR}/identity.json" 2>/dev/null || echo "${NOW}")",
-  "host": "${SERVER_IP}",
-  "status_url": "http://${SERVER_IP}/",
+  "host": "${MARVIN_DOMAIN}",
+  "domain": "${MARVIN_DOMAIN}",
+  "status_url": "https://${MARVIN_DOMAIN}/",
   "comm_port": 8042,
   "capabilities": ["system-management", "self-enhancement", "communication"],
   "uptime_seconds": $(cat /proc/uptime | cut -d' ' -f1 | cut -d'.' -f1),


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #67 — Warning: Full IP addresses of peer servers committed to identity.json

**Fix:** Replaced curl ifconfig.me IP lookup with domain name (robot-marvin.cz) in the identity.json template, preventing the server's full IP address from being written to the publicly tracked file. Also fixed http to https for status_url.

### Changed Files
```
agent/network-discovery.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #67*