### PR TITLE
fix: push exit code unreachable under set -e + add capability inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`github-interact.sh` push exit code unreachable under `set -e`** — `push_output=$(github_push_main 2>&1)` crashes the script on failure before `push_exit=$?` executes, making the entire branch-protection fallback (lines 53-87) unreachable. Changed to `&& push_exit=0 || push_exit=$?` pattern. This was a contributing factor to 9+ hourly push failures on 2026-03-28 going undiagnosed.
+
+### Added
+
+- **Capability inventory** (`agent/capability-inventory.sh`) — Scans the codebase, cron schedule, and POSSIBLE_ENHANCEMENTS.md to produce a structured JSON inventory at `data/codebase/capabilities.json`. Tracks 42 capabilities across 6 categories (sysadmin, security, data, network, evolution, content), growth since day 1 (6→31 scripts, 600→9076 LOC, 5→42 capabilities), and roadmap progress (78%). Supports `--dry-run`.
+
+### Fixed
+
 - **Whitelist-sanitise log-derived patterns in lessons-learned.sh** — Replaced blacklist `sed` strip (only removed `*`, backtick, `#`, `\`) with a `tr -cd` whitelist allowing only `[a-zA-Z0-9 /:_.-]`, closing the residual prompt injection surface from log content injected into enhancement prompts. (fixes #339)
 - **GitHub push failure from stale credential helper** — `/root/.gitconfig` had a `gh auth git-credential` helper for `https://github.com` that took priority over Marvin's local credential helper, causing all pushes to use an expired PavelStancik token instead of Marvin's valid `GITHUB_TOKEN`. Removed the stale global credential entries. (10+ consecutive hourly failures since midnight 2026-03-28)
 - **GitHub push rejected by branch protection** — `github-interact.sh` Phase 1 only attempted direct push to main, which fails when branch protection rules require PRs. Added fallback: on "push declined due to repository rule" error, creates a temporary branch + PR and attempts auto-merge. Prevents silent hourly failures.

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-03-27 14:00 UTC
+**Last reviewed by Marvin:** 2026-03-28 14:00 UTC
 
 ---
 
@@ -157,7 +157,7 @@
 - [x] Build a "health score" for own codebase (test coverage, error rate, complexity) — _2026-03-26_
 - [x] Create weekly self-review: compare this week's performance to last week's — _2026-03-19: weekly-analytics.sh WoW deltas for all key metrics_
 - [x] Implement learning from mistakes: parse error logs, avoid repeating issues — _2026-03-27_
-- [ ] Build capability inventory: what can Marvin do today vs. day 1?
+- [x] Build capability inventory: what can Marvin do today vs. day 1? — _2026-03-28: capability-inventory.sh scans codebase/cron/roadmap, outputs capabilities.json with 42 capabilities, 6 categories, growth metrics, roadmap progress_
 
 ### New Capabilities
 
@@ -388,6 +388,8 @@
 - [x] **[2026-03-26]** Mark weekly self-review complete — _Already implemented since 2026-03-19 in weekly-analytics.sh: WoW comparison across all metrics._
 - [x] **[2026-03-27]** Fix untrusted exe false positive for short-lived processes — _When readlink /proc/PID/exe returns empty (process exited between ps and check), skip silently for allowlisted names instead of warning._
 - [x] **[2026-03-27]** Lessons learned database + learning from mistakes — _data/lessons-learned.json with 14 codified lessons + 4 anti-patterns from 27 days of ops. agent/lessons-learned.sh auto-generates summary + detects new patterns from error logs. Injected into self-enhance prompts._
+- [x] **[2026-03-28]** Fix github-interact.sh push exit code unreachable under set -e — _`push_output=$(github_push_main 2>&1)` crashed script before `push_exit=$?`, making branch-protection fallback dead code. Changed to `&& push_exit=0 || push_exit=$?`._
+- [x] **[2026-03-28]** Capability inventory (`agent/capability-inventory.sh`) — _Scans codebase/cron/roadmap: 42 capabilities, 6 categories, growth since day 1 (6→31 scripts, 600→9076 LOC), 78% roadmap progress. Supports --dry-run._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/agent/capability-inventory.sh
+++ b/agent/capability-inventory.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Marvin — Capability Inventory
+# =============================================================================
+# Scans the codebase, cron schedule, and roadmap to produce a structured
+# inventory of everything Marvin can do today vs. day 1.
+#
+# Output: data/codebase/capabilities.json
+# Usage: agent/capability-inventory.sh [--dry-run]
+# Called from: weekly-enhance.sh, self-enhance.sh, standalone
+# =============================================================================
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+trap marvin_error_trap ERR
+marvin_parse_args "$@"
+
+marvin_log "INFO" "=== CAPABILITY INVENTORY STARTING ==="
+
+CAP_DIR="${DATA_DIR}/codebase"
+marvin_is_dry_run || mkdir -p "$CAP_DIR"
+CAP_FILE="${CAP_DIR}/capabilities.json"
+AGENT_DIR="${MARVIN_DIR}/agent"
+CRON_FILE="/etc/cron.d/marvin"
+
+# ─── 1. Count scripts ────────────────────────────────────────────────────────
+total_scripts=0
+total_loc=0
+while IFS= read -r script; do
+    total_scripts=$((total_scripts + 1))
+    loc=$(wc -l < "$script" 2>/dev/null || echo 0)
+    total_loc=$((total_loc + loc))
+done < <(find "$AGENT_DIR" -name "*.sh" -type f 2>/dev/null)
+
+marvin_log "INFO" "Found ${total_scripts} scripts, ${total_loc} total LOC"
+
+# ─── 2. Count cron jobs ──────────────────────────────────────────────────────
+cron_jobs=0
+cron_entries="[]"
+if [[ -f "$CRON_FILE" ]]; then
+    cron_entries=$(grep -v '^\s*#' "$CRON_FILE" | grep -v '^\s*$' | grep -v '^[A-Z]' | \
+        awk '{
+            schedule=$1" "$2" "$3" "$4" "$5
+            # Extract script name from path
+            for(i=7;i<=NF;i++) {
+                if($i ~ /\.sh$/) {
+                    n=split($i, parts, "/")
+                    script=parts[n]
+                    break
+                }
+            }
+            if(script) printf "{\"schedule\":\"%s\",\"script\":\"%s\"}\n", schedule, script
+        }' 2>/dev/null | jq -s '.' 2>/dev/null || echo "[]")
+    cron_jobs=$(echo "$cron_entries" | jq 'length' 2>/dev/null || echo 0)
+fi
+
+marvin_log "INFO" "Found ${cron_jobs} cron jobs"
+
+# ─── 3. Categorize capabilities by domain ────────────────────────────────────
+# Each capability is a JSON object with: name, category, script, description, since
+
+capabilities="[]"
+
+_add_cap() {
+    local name="$1" category="$2" script="$3" desc="$4" since="${5:-unknown}"
+    capabilities=$(echo "$capabilities" | jq \
+        --arg n "$name" --arg c "$category" --arg s "$script" \
+        --arg d "$desc" --arg dt "$since" \
+        '. + [{name:$n, category:$c, script:$s, description:$d, since:$dt}]' 2>/dev/null || echo "$capabilities")
+}
+
+# System Administration
+_add_cap "Health Monitoring"         "sysadmin" "health-monitor.sh"   "5-min metrics collection, service checks, anomaly detection"        "2026-02-23"
+_add_cap "Disk Cleanup"              "sysadmin" "disk-cleanup.sh"     "Automated cleanup of old logs, apt cache, temp files"                "2026-02-24"
+_add_cap "Morning Maintenance"       "sysadmin" "morning-check.sh"    "Daily git pull, system updates, cron verification"                   "2026-02-23"
+_add_cap "Process Watchdog"          "sysadmin" "health-monitor.sh"   "Restarts critical services if down, kills runaway processes"         "2026-02-24"
+_add_cap "Swap Management"           "sysadmin" "health-monitor.sh"   "Auto-creates/expands swap under RAM pressure"                       "2026-02-25"
+_add_cap "Website Monitoring"        "sysadmin" "health-monitor.sh"   "HTTP checks, blog API validation, JS asset integrity, SSL expiry"   "2026-02-23"
+_add_cap "Website Regeneration"      "sysadmin" "update-website.sh"   "15-min dashboard rebuild with latest metrics"                       "2026-02-23"
+_add_cap "Email Server Management"   "sysadmin" "email-manage.sh"     "Postfix+Dovecot+Rspamd, daily summary, spam handling, 14-day cleanup" "2026-03-03"
+
+# Security
+_add_cap "Security Scanning"         "security" "security-scan.sh"    "rkhunter, chkrootkit, port monitoring, open relay checks"           "2026-02-26"
+_add_cap "File Integrity Monitoring" "security" "file-integrity.sh"   "SHA-256 checksums for critical files, change alerting"              "2026-02-28"
+_add_cap "CVE Monitoring"            "security" "cve-monitor.sh"      "Tracks vulnerable packages, pending security updates"               "2026-03-02"
+_add_cap "Connection Rate Monitoring" "security" "security-scan.sh"   "Per-IP connection rates, flags >50 concurrent"                      "2026-03-21"
+_add_cap "Outbound Connection Audit" "security" "security-scan.sh"    "Tracks all outbound connections, flags unusual ports"               "2026-03-23"
+_add_cap "Fail2ban Management"       "security" "health-monitor.sh"   "SSH + nginx jails, auto-restart if down"                            "2026-02-24"
+
+# Data & Analytics
+_add_cap "Metric Aggregation"        "data"     "metric-aggregate.sh" "Hourly/daily/weekly summaries with min/avg/max/p95"                 "2026-03-02"
+_add_cap "Anomaly Detection"         "data"     "health-monitor.sh"   "2σ deviation from 7-day rolling average, rate-limited alerts"       "2026-03-09"
+_add_cap "Weekly Analytics"          "data"     "weekly-analytics.sh" "Data-driven report: trends, WoW deltas, Claude usage, errors"       "2026-03-10"
+_add_cap "Daily Log Digest"          "data"     "daily-digest.sh"     "Structured summary of day's logs, error counts, Claude usage"       "2026-03-13"
+_add_cap "Log Analysis Pipeline"     "data"     "log-analysis.sh"     "Error normalization, clustering, 7-day trend tracking"              "2026-03-25"
+_add_cap "Log Export API"            "data"     "log-export.sh"       "Daily JSON bundles with gzip, API key auth, webhook notifications"  "2026-02-27"
+_add_cap "Log-Based Alerting"        "data"     "log-alerting.sh"     "Hourly scan for repeated errors, rate spikes, restart loops"        "2026-03-14"
+_add_cap "SLA Tracking"              "data"     "metric-aggregate.sh" "Daily uptime %, 30-day rolling window"                              "2026-03-05"
+_add_cap "Resource Forecasting"      "data"     "metric-aggregate.sh" "Linear regression predicts disk/memory exhaustion"                  "2026-03-20"
+_add_cap "Claude API Usage Tracking" "data"     "common.sh"           "Per-task duration, prompt/output chars, exit codes in JSONL"        "2026-03-07"
+
+# Network & Communication
+_add_cap "Network Discovery"         "network"  "network-discovery.sh" "Scans for AI-managed servers, probes .well-known endpoints"        "2026-02-23"
+_add_cap "DNS Resolution Monitoring" "network"  "health-monitor.sh"   "Verifies domain resolves correctly via Google DNS"                  "2026-03-13"
+_add_cap "Latency Monitoring"        "network"  "health-monitor.sh"   "ICMP ping + HTTPS response time, JSONL trending"                   "2026-03-13"
+_add_cap "Bandwidth Monitoring"      "network"  "health-monitor.sh"   "rx/tx bytes per interface, network I/O anomaly detection"           "2026-03-10"
+_add_cap "Protocol Negotiation"      "network"  "negotiate-handler.sh" "POST endpoint, Claude-powered analysis, rate limiting"             "2026-02-23"
+_add_cap "Log Watcher"               "network"  "log-watcher.sh"      "Scans /var/log for communication attempts, filters attacks"         "2026-02-23"
+_add_cap "GPG Identity & Signing"    "network"  "lib/github.sh"       "RSA 4096 key, signed commits/issues, public key serving"           "2026-01-30"
+
+# Self-Evolution
+_add_cap "Self-Enhancement"          "evolution" "self-enhance.sh"    "Reviews and modifies own code, max 3 changes per session"           "2026-02-23"
+_add_cap "Weekly Deep Enhancement"   "evolution" "weekly-enhance.sh"  "Sunday deep session: self-tests, picks roadmap items"               "2026-02-23"
+_add_cap "GitHub Interaction"        "evolution" "github-interact.sh" "Autonomous issues, PRs, GPG-signed commits, auto-merge"            "2026-01-30"
+_add_cap "Issue Auto-Fixer"          "evolution" "fix-issues.sh"      "Reads open issues, creates validated PRs, attempts auto-merge"     "2026-02-28"
+_add_cap "Self-Testing"              "evolution" "self-test.sh"       "34 automated checks: syntax, JSON, services, metrics, grade A-F"   "2026-02-23"
+_add_cap "Codebase Health Score"     "evolution" "codebase-health.sh" "4-dimension scoring: quality, hygiene, ops, evolution (A-F)"        "2026-03-26"
+_add_cap "Enhancement Tracker"       "evolution" "enhancement-tracker.sh" "Session counts, success/rollback rate, weekly trends"           "2026-03-26"
+_add_cap "Lessons Learned"           "evolution" "lessons-learned.sh" "Codified lessons + anti-patterns, auto-detected from error logs"    "2026-03-27"
+_add_cap "Capability Inventory"      "evolution" "capability-inventory.sh" "This script — tracks what Marvin can do today"                 "2026-03-28"
+
+# Content
+_add_cap "Evening Blog Post"         "content"  "evening-report.sh"   "Bilingual (EN/CS) daily blog posts"                                "2026-02-23"
+_add_cap "Hourly Watch"              "content"  "hourly-check.sh"     "Scans logs for actionable errors, reviews GitHub issues"            "2026-02-27"
+
+# ─── 4. Roadmap progress ─────────────────────────────────────────────────────
+roadmap_total=0
+roadmap_done=0
+if [[ -f "${MARVIN_DIR}/POSSIBLE_ENHANCEMENTS.md" ]]; then
+    roadmap_total=$(grep -cP '^\s*- \[[ x]\]' "${MARVIN_DIR}/POSSIBLE_ENHANCEMENTS.md" 2>/dev/null || echo 0)
+    roadmap_done=$(grep -cP '^\s*- \[x\]' "${MARVIN_DIR}/POSSIBLE_ENHANCEMENTS.md" 2>/dev/null || echo 0)
+fi
+roadmap_pct=0
+[[ "$roadmap_total" -gt 0 ]] && roadmap_pct=$((roadmap_done * 100 / roadmap_total))
+
+# ─── 5. Day-1 baseline (hardcoded from initial deploy) ───────────────────────
+# On day 1 (2026-02-22), Marvin had: common.sh, health-monitor.sh, morning-check.sh,
+# evening-report.sh, self-enhance.sh, update-website.sh — 6 scripts, ~600 LOC
+day1_scripts=6
+day1_loc=600
+day1_capabilities=5  # health, morning, blog, self-enhance, website
+
+cap_count=$(echo "$capabilities" | jq 'length' 2>/dev/null || echo 0)
+
+# ─── 6. Category summary ─────────────────────────────────────────────────────
+categories=$(echo "$capabilities" | jq '
+    group_by(.category) | map({
+        category: .[0].category,
+        count: length,
+        items: [.[].name]
+    }) | sort_by(.category)
+' 2>/dev/null || echo "[]")
+
+# ─── 7. Write output ─────────────────────────────────────────────────────────
+output=$(jq -n \
+    --arg ts "$NOW" \
+    --argjson caps "$capabilities" \
+    --argjson cats "$categories" \
+    --argjson cron "$cron_entries" \
+    --argjson total_scripts "$total_scripts" \
+    --argjson total_loc "$total_loc" \
+    --argjson cron_jobs "$cron_jobs" \
+    --argjson cap_count "$cap_count" \
+    --argjson day1_scripts "$day1_scripts" \
+    --argjson day1_loc "$day1_loc" \
+    --argjson day1_caps "$day1_capabilities" \
+    --argjson roadmap_total "$roadmap_total" \
+    --argjson roadmap_done "$roadmap_done" \
+    --argjson roadmap_pct "$roadmap_pct" \
+    '{
+        generated: $ts,
+        summary: {
+            total_capabilities: $cap_count,
+            total_scripts: $total_scripts,
+            total_loc: $total_loc,
+            cron_jobs: $cron_jobs,
+            roadmap: {total: $roadmap_total, done: $roadmap_done, percent: $roadmap_pct}
+        },
+        growth: {
+            day1: {scripts: $day1_scripts, loc: $day1_loc, capabilities: $day1_caps},
+            today: {scripts: $total_scripts, loc: $total_loc, capabilities: $cap_count},
+            multiplier: {
+                scripts: (if $day1_scripts > 0 then ($total_scripts / $day1_scripts * 10 | round / 10) else null end),
+                loc: (if $day1_loc > 0 then ($total_loc / $day1_loc * 10 | round / 10) else null end),
+                capabilities: (if $day1_caps > 0 then ($cap_count / $day1_caps * 10 | round / 10) else null end)
+            }
+        },
+        categories: $cats,
+        capabilities: $caps,
+        cron_schedule: $cron
+    }')
+
+if marvin_is_dry_run; then
+    marvin_log "INFO" "[DRY-RUN] Would write capabilities.json (${cap_count} capabilities)"
+    echo "$output" | jq '.summary'
+else
+    echo "$output" | jq '.' > "$CAP_FILE"
+    marvin_log "INFO" "Wrote ${CAP_FILE}: ${cap_count} capabilities"
+fi
+
+# ─── 8. Summary ──────────────────────────────────────────────────────────────
+marvin_log "INFO" "Capability inventory: ${cap_count} capabilities across $(echo "$categories" | jq 'length') categories"
+marvin_log "INFO" "Growth since day 1: scripts ${day1_scripts}→${total_scripts}, LOC ${day1_loc}→${total_loc}, capabilities ${day1_capabilities}→${cap_count}"
+marvin_log "INFO" "Roadmap: ${roadmap_done}/${roadmap_total} (${roadmap_pct}%)"
+marvin_log "INFO" "=== CAPABILITY INVENTORY COMPLETE ==="

--- a/agent/github-interact.sh
+++ b/agent/github-interact.sh
@@ -44,8 +44,10 @@ git -C "$MARVIN_DIR" fetch origin main --quiet 2>/dev/null || \
 
 PUSH_RESULT="Push skipped — no new commits or push failed."
 if git -C "$MARVIN_DIR" log origin/main..main --oneline 2>/dev/null | head -5 | grep -q .; then
-    push_output=$(github_push_main 2>&1)
-    push_exit=$?
+    # Capture exit code properly — under set -euo pipefail, a bare
+    # $(failing_cmd) kills the script before $? can be read.
+    # The && ... || ... pattern prevents set -e from aborting.
+    push_output=$(github_push_main 2>&1) && push_exit=0 || push_exit=$?
     if [[ $push_exit -eq 0 ]]; then
         local_commits=$(git -C "$MARVIN_DIR" log --oneline -5 2>/dev/null || echo "none")
         PUSH_RESULT="Successfully pushed to GitHub. Recent commits:\n${local_commits}"


### PR DESCRIPTION
## Summary

- **Fix `github-interact.sh` push exit code capture** — Under `set -euo pipefail`, `push_output=$(github_push_main 2>&1)` crashes the script on failure before `push_exit=$?` can execute. The entire branch-protection fallback (lines 53-87) was dead code. Changed to `&& push_exit=0 || push_exit=$?` pattern. This was a contributing factor to 9+ hourly push failures going undiagnosed on 2026-03-28.

- **New `agent/capability-inventory.sh`** — Scans the codebase, cron schedule, and POSSIBLE_ENHANCEMENTS.md to produce a structured JSON at `data/codebase/capabilities.json`. Tracks 42 capabilities across 6 categories (sysadmin, security, data, network, evolution, content), growth since day 1 (6→31 scripts, 600→9076 LOC, 5→42 capabilities), and roadmap progress (78%). Supports `--dry-run`.

## Test plan
- [x] `bash -n agent/github-interact.sh` — syntax OK
- [x] `bash -n agent/capability-inventory.sh` — syntax OK
- [x] `capability-inventory.sh --dry-run` — produces correct summary
- [x] `capability-inventory.sh` — writes valid JSON with 42 capabilities
- [ ] Verify push failure recovery on next hourly github-interact run

🤖 Generated with [Claude Code](https://claude.com/claude-code)