### PR TITLE
fix: warn on stale active incidents instead of archiving (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Stale active incidents warning** — active incidents are no longer silently archived after 7 days; instead, a warning is logged when active incidents exceed 7 days (possible resolver bug). Resolved incidents are still archived normally. Prevents data loss while surfacing accumulation issues. (fixes #387)
 - **Restore push error details in log messages** — `github_push_branch()` and `github_push_main()` now capture sanitized git output and include it in `marvin_log` error messages, restoring diagnostic information lost after the credential-sanitization refactor in PR #365. (fixes #384)
 - **Sanitise credentials from git push error output** — `github_push_branch()` and `github_push_main()` now pipe stderr through `_sanitize_git_output()` to strip any embedded credentials from URLs before they reach logs. Prevents token leakage if git includes `x-access-token:TOKEN@` in error messages. (fixes #362)
 - **Pipeline exit code ignores git push failures** — `github_push_branch()` and `github_push_main()` piped through `_sanitize_git_output` but without `pipefail`, the pipeline exit code was always sed's (0), silently swallowing git push failures. Now uses `PIPESTATUS[0]` to capture git's actual exit code. (fixes #366)

--- a/agent/incident-report.sh
+++ b/agent/incident-report.sh
@@ -386,15 +386,22 @@ if [[ "$DO_CLOSE" == "true" ]]; then
         fi
     done
 
-    # Archive incidents older than 7 days (resolved by resolved_at, active by opened_at)
-    # This prevents stale active incidents from accumulating indefinitely (#361)
+    # Archive resolved incidents older than 7 days (active incidents are kept indefinitely)
     week_ago=$(date -u -d "${TODAY} - 7 days" +%Y-%m-%dT00:00:00Z 2>/dev/null || echo "")
     if [[ -n "$week_ago" ]]; then
+        # Warn about suspiciously old active incidents (do not archive them)
+        stale_count=$(jq --arg cutoff "$week_ago" \
+            '[.incidents[] | select(.status == "active" and .opened_at < $cutoff)] | length' \
+            "$ACTIVE_FILE" 2>/dev/null || echo 0)
+        if [[ "${stale_count:-0}" -gt 0 ]]; then
+            marvin_log "WARN" "Found ${stale_count} active incident(s) older than 7 days — possible resolver bug"
+        fi
+
         (
             flock -w 10 200 || { marvin_log "WARN" "Failed to acquire lock for archive cleanup"; exit 1; }
             jq --arg cutoff "$week_ago" \
                 '.incidents |= [.[] | select(
-                    (.status == "active" and .opened_at > $cutoff) or
+                    (.status == "active") or
                     (.status != "active" and .resolved_at > $cutoff)
                 )]' \
                 "$ACTIVE_FILE" > "${ACTIVE_FILE}.tmp" && mv "${ACTIVE_FILE}.tmp" "$ACTIVE_FILE"


### PR DESCRIPTION
## Summary

- Active incidents older than 7 days are now **kept indefinitely** instead of being silently dropped from `active-incidents.json`
- A **warning is logged** when stale active incidents are detected (`"Found N active incident(s) older than 7 days — possible resolver bug"`)
- Resolved incidents are still archived after 7 days as before

This addresses the unbounded accumulation risk identified in #387 without reintroducing the data loss bug from #383. The warning surfaces resolver failures so they can be investigated rather than masked.

Fixes #387

## Test plan

- [ ] Run `incident-report.sh --close` with an active incident older than 7 days — verify warning is logged and incident is NOT removed
- [ ] Run `incident-report.sh --close` with a resolved incident older than 7 days — verify it IS archived
- [ ] Verify `bash -n agent/incident-report.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)