### PR TITLE
fix: #383 bug: incident-report.sh archives long-running active inciden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Archiving logic drops long-running active incidents** — The 7-day cleanup in `incident-report.sh` filtered active incidents by `opened_at`, silently removing any unresolved incident older than a week. Now keeps all active incidents regardless of age; only resolved incidents are archived after 7 days. (fixes #383)
 - **Sanitise credentials from git push error output** — `github_push_branch()` and `github_push_main()` now pipe stderr through `_sanitize_git_output()` to strip any embedded credentials from URLs before they reach logs. Prevents token leakage if git includes `x-access-token:TOKEN@` in error messages. (fixes #362)
 - **Pipeline exit code ignores git push failures** — `github_push_branch()` and `github_push_main()` piped through `_sanitize_git_output` but without `pipefail`, the pipeline exit code was always sed's (0), silently swallowing git push failures. Now uses `PIPESTATUS[0]` to capture git's actual exit code. (fixes #366)
 

--- a/agent/incident-report.sh
+++ b/agent/incident-report.sh
@@ -386,15 +386,14 @@ if [[ "$DO_CLOSE" == "true" ]]; then
         fi
     done
 
-    # Archive incidents older than 7 days (resolved by resolved_at, active by opened_at)
-    # This prevents stale active incidents from accumulating indefinitely (#361)
+    # Archive resolved incidents older than 7 days; keep all active incidents (#383).
     week_ago=$(date -u -d "${TODAY} - 7 days" +%Y-%m-%dT00:00:00Z 2>/dev/null || echo "")
     if [[ -n "$week_ago" ]]; then
         (
             flock -w 10 200 || { marvin_log "WARN" "Failed to acquire lock for archive cleanup"; exit 1; }
             jq --arg cutoff "$week_ago" \
                 '.incidents |= [.[] | select(
-                    (.status == "active" and .opened_at > $cutoff) or
+                    .status == "active" or
                     (.status != "active" and .resolved_at > $cutoff)
                 )]' \
                 "$ACTIVE_FILE" > "${ACTIVE_FILE}.tmp" && mv "${ACTIVE_FILE}.tmp" "$ACTIVE_FILE"


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #383 — bug: incident-report.sh archives long-running active incidents after 7 days

**Fix:** Changed the archiving jq filter to keep all active incidents regardless of age, only applying the 7-day cutoff to resolved incidents. This prevents silent data loss for persistent unresolved incidents.

### Changed Files
```
CHANGELOG.md
agent/incident-report.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #383*