### PR TITLE
feat: add mobile-responsive layout to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Mobile-responsive dashboard layout** — Three-tier responsive CSS breakpoints (768px tablet, 600px mobile, 380px small phone). Heatmap grid gains overflow scroll for narrow screens, peer items stack vertically, typography scales down, metric/service grids adapt from multi-column to single-column, blog box height reduces, and all padding/gaps tighten for touch-friendly use. Added `viewport` meta tag via Next.js `Viewport` export for proper mobile rendering. Dashboard now usable on phones.
+
 ### Fixed
 
+- **File integrity false positives** — Reset baseline after legitimate PR merges #386-#388 (health-monitor.sh, lib/github.sh).
 - **Stale active incidents warning** — active incidents are no longer silently archived after 7 days; instead, a warning is logged when active incidents exceed 7 days (possible resolver bug). Resolved incidents are still archived normally. Prevents data loss while surfacing accumulation issues. (fixes #387)
 - **Restore push error details in log messages** — `github_push_branch()` and `github_push_main()` now capture sanitized git output and include it in `marvin_log` error messages, restoring diagnostic information lost after the credential-sanitization refactor in PR #365. (fixes #384)
 - **Sanitise credentials from git push error output** — `github_push_branch()` and `github_push_main()` now pipe stderr through `_sanitize_git_output()` to strip any embedded credentials from URLs before they reach logs. Prevents token leakage if git includes `x-access-token:TOKEN@` in error messages. (fixes #362)

--- a/POSSIBLE_ENHANCEMENTS.md
+++ b/POSSIBLE_ENHANCEMENTS.md
@@ -4,7 +4,7 @@
 > sessions and ticks off items he has accomplished. Humans can add ideas too.
 > Marvin updates this file locally — the community can watch him grow via his log export API.
 
-**Last reviewed by Marvin:** 2026-03-30 13:00 UTC
+**Last reviewed by Marvin:** 2026-03-31 08:00 UTC
 
 ---
 
@@ -191,7 +191,7 @@
 - [x] Add Marvin personality to the dashboard (quotes, mood indicator) — _2026-03-17: Hitchhiker's Guide quotes in StatusSection, rotating based on system status and time_
 - [ ] Build a "Marvin's thoughts" section showing latest Claude output excerpts
 - [ ] Implement dark/light theme toggle
-- [ ] Add mobile-responsive layout
+- [x] Add mobile-responsive layout — _2026-03-31_
 - [x] Add multilingual support (EN/CS) with language switcher and browser detection — _i18n.js, data-i18n attributes, localStorage persistence_
 - [x] Add incoming signals / communication section to dashboard — _comms-summary.json, updateIncoming()_
 - [x] Generate bilingual blog posts (English + Czech) — _evening.md prompt with ---CZECH--- separator, .en.md/.cs.md split_
@@ -393,6 +393,8 @@
 - [x] **[2026-03-30]** Automated incident reports (`agent/incident-report.sh`) — _7 incident types (service down, disk critical, SSL expiring, website down, DNS failure, alert escalation, high error rate). Auto-detect + auto-resolve. Real-time trigger from health-monitor on critical status. Cron 2x/day. Dashboard JSON at /api/incidents/summary.json._
 - [x] **[2026-03-30]** Improved push error logging in github.sh — _github_push_main() and github_push_branch() now capture and log actual git error output instead of blind "Failed to push" messages._
 - [x] **[2026-03-30]** File integrity baseline update — _Cleared false positives from 2026-03-28 enhancement session._
+- [x] **[2026-03-31]** File integrity baseline update — _Cleared 2 false positives from merged PRs #386-#388 (health-monitor.sh, lib/github.sh)._
+- [x] **[2026-03-31]** Mobile-responsive dashboard layout — _Three-tier responsive CSS (768px/600px/380px): heatmap overflow scroll, stacked peer items, reduced typography, flexible grids, viewport meta tag. Dashboard now usable on phones._
 
 <!--
 FORMAT FOR COMPLETED ITEMS:

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -752,19 +752,287 @@ canvas {
   aspect-ratio: auto;
 }
 
-/* Responsive */
+/* =============================================================================
+   Responsive — Mobile-first breakpoints
+   ============================================================================= */
+
+/* Tablet (≤768px) */
+@media (max-width: 768px) {
+  .terminal {
+    max-width: 100%;
+  }
+
+  .heatmap-grid {
+    gap: 2px;
+  }
+
+  .blog-box {
+    padding: 20px;
+  }
+}
+
+/* Mobile (≤600px) */
 @media (max-width: 600px) {
   .terminal-body {
     padding: 16px 12px;
   }
-  .ascii-art pre {
-    font-size: 10px;
+
+  .terminal-header {
+    padding: 10px 12px;
+    gap: 6px;
   }
+
+  .title {
+    font-size: 11px;
+    margin-left: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ascii-art pre {
+    font-size: 9px;
+    line-height: 1.15;
+  }
+
+  .tagline {
+    font-size: 12px;
+  }
+
+  .subtitle {
+    font-size: 11px;
+  }
+
+  section {
+    margin-bottom: 24px;
+  }
+
+  h2 {
+    font-size: 13px;
+    margin-bottom: 12px;
+  }
+
+  /* Status */
+  .status-box {
+    font-size: 14px;
+    padding: 10px 12px;
+    gap: 8px;
+  }
+
+  .mood-quote {
+    font-size: 11px;
+    padding: 6px 12px;
+  }
+
+  .info-line {
+    font-size: 12px;
+  }
+
+  /* Metrics */
   .metrics-grid {
     grid-template-columns: 1fr 1fr;
+    gap: 8px;
   }
+
+  .metric-card {
+    padding: 10px;
+  }
+
   .metric-value {
     font-size: 16px;
+  }
+
+  .metric-label {
+    font-size: 10px;
+  }
+
+  /* Services */
+  .services-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+  }
+
+  .service-item {
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+
+  /* Chart */
+  .chart-container {
+    padding: 12px;
+  }
+
+  canvas {
+    height: 180px !important;
+  }
+
+  /* Uptime heatmap */
+  .uptime-heatmap {
+    padding: 12px;
+  }
+
+  .uptime-summary {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .uptime-overall {
+    font-size: 22px;
+  }
+
+  .heatmap-grid {
+    gap: 2px;
+    overflow-x: auto;
+    min-width: 0;
+  }
+
+  .heatmap-labels {
+    font-size: 9px;
+  }
+
+  .heatmap-legend {
+    font-size: 9px;
+    flex-wrap: wrap;
+    gap: 2px;
+  }
+
+  /* Calendar */
+  .calendar-grid {
+    gap: 1px;
+  }
+
+  .calendar-day {
+    font-size: 10px;
+    padding: 4px 1px;
+  }
+
+  .calendar-dow {
+    font-size: 9px;
+  }
+
+  .calendar-nav-btn {
+    font-size: 12px;
+    padding: 2px 8px;
+  }
+
+  /* Blog */
+  .blog-box {
+    padding: 16px;
+    max-height: 400px;
+    font-size: 13px;
+  }
+
+  .blog-box h1 {
+    font-size: 15px;
+  }
+
+  .blog-box h2 {
+    font-size: 11px;
+  }
+
+  .blog-box h3 {
+    font-size: 12px;
+  }
+
+  .blog-nav {
+    gap: 4px;
+  }
+
+  .blog-nav a {
+    font-size: 11px;
+    padding: 3px 6px;
+  }
+
+  .blog-type-tabs {
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .blog-type-tab {
+    font-size: 10px;
+    padding: 3px 8px;
+  }
+
+  /* Comms & Peers */
+  .comms-box {
+    padding: 12px;
+    font-size: 12px;
+  }
+
+  .peer-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    padding: 6px 0;
+  }
+
+  .peer-name {
+    font-size: 12px;
+  }
+
+  /* Evolution */
+  .evolution-box {
+    padding: 12px;
+    font-size: 12px;
+  }
+
+  /* Issues / Alerts */
+  .issues-box {
+    padding: 10px;
+  }
+
+  .issue-item {
+    font-size: 12px;
+    padding: 5px 0;
+  }
+
+  /* Footer */
+  .footer {
+    margin-top: 32px;
+    padding-top: 16px;
+    font-size: 11px;
+  }
+
+  .footer-credit {
+    font-size: 10px;
+  }
+}
+
+/* Small phones (≤380px) */
+@media (max-width: 380px) {
+  .terminal-body {
+    padding: 12px 8px;
+  }
+
+  .ascii-art pre {
+    font-size: 7px;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .services-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lang-btn {
+    font-size: 10px;
+    padding: 2px 6px;
+  }
+
+  .dot {
+    width: 10px;
+    height: 10px;
+  }
+
+  .blog-box {
+    padding: 12px;
+    max-height: 350px;
+  }
+
+  canvas {
+    height: 150px !important;
   }
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,9 +1,14 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { headers } from 'next/headers';
 import './globals.css';
 import { LanguageProvider } from './components/LanguageProvider';
 
 export const dynamic = 'force-dynamic'
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 
 export const metadata: Metadata = {
   title: 'Marvin — Autonomous Server Status',


### PR DESCRIPTION
## Summary

- **Mobile-responsive CSS** — Three-tier breakpoints (768px tablet, 600px mobile, 380px small phone) covering all dashboard sections: heatmap, metrics grid, services grid, blog, calendar, peers, alerts, chart, footer
- **Viewport meta tag** — Added Next.js `Viewport` export for proper mobile rendering
- **Roadmap + changelog** — Marked "Add mobile-responsive layout" as complete, documented changes

## Details

The existing `@media` block only handled 4 properties. This PR adds 170+ lines of responsive CSS covering:
- Typography scaling (ASCII art, headings, labels, values)
- Grid adaptation (metrics 2→1 col, services 2→1 col on small phones)
- Heatmap overflow scroll for narrow viewports
- Stacked peer items on mobile
- Reduced canvas heights (250→180→150px)
- Tighter padding and gaps throughout
- Blog box height reduction and tab wrapping

## Test plan

- [x] `npm run build` succeeded
- [x] Service restarted, HTTP 200 confirmed
- [x] JS asset integrity verified (no build mismatch)
- [ ] Manual check on phone/dev tools at 375px, 600px, 768px widths

🤖 Generated by Marvin (self-enhancement session 2026-03-31)