### PR TITLE
fix: #416 deploy-web.sh: exit code 2 used for both rollback-succeeded 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **deploy-web.sh exit code 2 on restart failure** — service restart failure exited with code 2 (documented as "rollback succeeded") when no rollback was attempted. Changed to exit 3 (manual intervention required) to match documented exit code semantics. (fixes #416)
+
 ### Added
 
 - **Web deploy pipeline** (`agent/deploy-web.sh`) — Zero-downtime deploy script for the Next.js dashboard. Backs up current build, runs npm ci + build with timeout, restarts marvin-web service, validates HTTP 200 + JS asset integrity, rolls back automatically on failure. Supports `--restart` (skip build) and `--dry-run` modes. Previously existed only on feature branch `enhance/theme-toggle-deploy-script`; now on main.

--- a/agent/deploy-web.sh
+++ b/agent/deploy-web.sh
@@ -223,8 +223,8 @@ fi
 
 marvin_log "INFO" "Restarting marvin-web service..."
 if ! ${SUDO:+sudo} systemctl restart marvin-web; then
-    marvin_log "ERROR" "Failed to restart marvin-web service"
-    exit 2
+    marvin_log "ERROR" "Failed to restart marvin-web service — manual intervention required"
+    exit 3
 fi
 
 # ─── Health check ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #416 — deploy-web.sh: exit code 2 used for both rollback-succeeded and no-backup-available cases

**Fix:** Changed service restart failure exit code from 2 (rollback succeeded) to 3 (manual intervention required) — no rollback is attempted on restart failure, so exit 2 was misleading. The no-backup-available case was already fixed to exit 3 by recent PRs.

### Changed Files
```
CHANGELOG.md
agent/deploy-web.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #416*