### PR TITLE
fix: #427 deploy-web.sh: rollback health check timeout too short (5s v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **deploy-web.sh rollback health check too short** — post-rollback health check used a single `sleep 5` + one HTTP request, which could fail on a slow VPS. Replaced with a retry loop (up to 30s, reusing the 3s sleep interval) matching the main deploy health check pattern. (fixes #427)
 - **deploy-web.sh exit code 2 on restart failure** — service restart failure exited with code 2 (documented as "rollback succeeded") when no rollback was attempted. Changed to exit 3 (manual intervention required) to match documented exit code semantics. (fixes #416)
 
 ### Added

--- a/agent/deploy-web.sh
+++ b/agent/deploy-web.sh
@@ -293,14 +293,26 @@ else
 
             marvin_log "INFO" "Backup restored — restarting service..."
             if ${SUDO:+sudo} systemctl restart marvin-web; then
-                # Brief health check on rolled-back build
-                sleep 5
-                _rb_code=$(curl -so /dev/null -w '%{http_code}' --max-time 5 "${LOCAL_URL}/" 2>/dev/null || echo "000")
-                if [[ "$_rb_code" == "200" ]]; then
-                    marvin_log "INFO" "Rollback successful — service restored (HTTP ${_rb_code})"
+                # Health check on rolled-back build — loop like the main deploy check
+                _rb_max_wait=30
+                _rb_waited=0
+                _rb_ok=false
+                marvin_log "INFO" "Waiting for rollback health check (max ${_rb_max_wait}s)..."
+                while [[ "$_rb_waited" -lt "$_rb_max_wait" ]]; do
+                    sleep "$_sleep_interval"
+                    _rb_waited=$((_rb_waited + _sleep_interval))
+                    _rb_code=$(curl -so /dev/null -w '%{http_code}' --max-time 5 "${LOCAL_URL}/" 2>/dev/null || echo "000")
+                    if [[ "$_rb_code" == "200" ]]; then
+                        _rb_ok=true
+                        break
+                    fi
+                    marvin_log "INFO" "Rollback health check: HTTP ${_rb_code} (waiting...)"
+                done
+                if [[ "$_rb_ok" == "true" ]]; then
+                    marvin_log "INFO" "Rollback successful — service restored (HTTP ${_rb_code}, ${_rb_waited}s)"
                     exit 2
                 else
-                    marvin_log "WARN" "Rollback service started but health check returned HTTP ${_rb_code}"
+                    marvin_log "WARN" "Rollback service started but health check failed after ${_rb_max_wait}s (last HTTP ${_rb_code})"
                     exit 3
                 fi
             else


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #427 — deploy-web.sh: rollback health check timeout too short (5s vs 60s)

**Fix:** Replaced the single `sleep 5` + one HTTP request post-rollback health check with a retry loop (up to 30s with 3s intervals, ~10 attempts), matching the pattern used by the main deploy health check. This prevents false rollback failures on a slow-starting VPS.

### Changed Files
```
CHANGELOG.md
agent/deploy-web.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #427*