### PR TITLE
fix: #427 deploy-web.sh: rollback health check timeout too short (5s v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Rollback health check retry loop** — Post-rollback health check in `deploy-web.sh` used a single `sleep 5` + one HTTP request, which was insufficient for slow-starting services. Replaced with a 30-second retry loop (3s intervals, up to ~10 attempts) matching the deploy health check pattern. (fixes #427)
 - **Stop futile PR auto-merge attempts** (`github-interact.sh`) — Branch protection requires review approval before merge. The script was calling `github_merge_pr` immediately after creating PRs, generating HTTP 405 ERROR logs 3x/day. Now skips auto-merge and logs INFO that PR awaits review.
 - **Backup security: exclude private key material** (`backup.sh`) — GPG private keys and SSL certificate private keys are no longer included in the unencrypted backup tarball. GPG public keyring and trust DB are still backed up; SSL renewal configs are backed up (certs are renewable via Let's Encrypt). Backup directory hardened to `chmod 700`. (fixes #438)
 - **Backup restore argument parsing** (`backup.sh`) — `--restore` without a filename no longer silently falls through to create a backup. Now prints usage and exits with error. (fixes #439)

--- a/agent/deploy-web.sh
+++ b/agent/deploy-web.sh
@@ -293,14 +293,26 @@ else
 
             marvin_log "INFO" "Backup restored — restarting service..."
             if ${SUDO:+sudo} systemctl restart marvin-web; then
-                # Brief health check on rolled-back build
-                sleep 5
-                _rb_code=$(curl -so /dev/null -w '%{http_code}' --max-time 5 "${LOCAL_URL}/" 2>/dev/null || echo "000")
-                if [[ "$_rb_code" == "200" ]]; then
-                    marvin_log "INFO" "Rollback successful — service restored (HTTP ${_rb_code})"
+                # Health check on rolled-back build (same retry pattern as deploy)
+                _rb_max_wait=30
+                _rb_waited=0
+                _rb_ok=false
+                marvin_log "INFO" "Rollback health check (max ${_rb_max_wait}s)..."
+                while [[ "$_rb_waited" -lt "$_rb_max_wait" ]]; do
+                    sleep "$_sleep_interval"
+                    _rb_waited=$((_rb_waited + _sleep_interval))
+                    _rb_code=$(curl -so /dev/null -w '%{http_code}' --max-time 5 "${LOCAL_URL}/" 2>/dev/null || echo "000")
+                    if [[ "$_rb_code" == "200" ]]; then
+                        _rb_ok=true
+                        break
+                    fi
+                    marvin_log "INFO" "Rollback health check: HTTP ${_rb_code} (waiting...)"
+                done
+                if [[ "$_rb_ok" == "true" ]]; then
+                    marvin_log "INFO" "Rollback successful — service restored (HTTP ${_rb_code}, ${_rb_waited}s)"
                     exit 2
                 else
-                    marvin_log "WARN" "Rollback service started but health check returned HTTP ${_rb_code}"
+                    marvin_log "WARN" "Rollback service started but health check failed after ${_rb_max_wait}s (last HTTP ${_rb_code})"
                     exit 3
                 fi
             else


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #427 — deploy-web.sh: rollback health check timeout too short (5s vs 60s)

**Fix:** Replaced the single sleep 5 + one HTTP request in the post-rollback health check with a 30-second retry loop (3s intervals, ~10 attempts), matching the deploy health check pattern so slow-starting services get adequate time to respond.

### Changed Files
```
CHANGELOG.md
agent/deploy-web.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #427*