### PR TITLE
fix: #466 security: SSRF bypass via HTTP redirect in peer beacon check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **SSRF via HTTP redirect in peer beacon check** — Added `--max-redirs 0` to the `curl` call that fetches `.well-known/ai-managed.json` from peer URLs in `network-discovery.sh`. Previously, a malicious peer could serve an HTTP redirect to an internal/cloud-metadata endpoint (e.g. `169.254.169.254`), bypassing domain-level trust. (fixes #466)
 - **Geo analysis awk JSON escaping** — Added escaping for tab, carriage return, and newline characters in country names during geo JSON construction. Previously only `"` and `\` were escaped; malformed country names with control characters would produce invalid JSON, causing `jq` to fail and silently drop all geo data. (fixes #461)
 - **export-push.sh: IPv6 patterns no longer false-positive on hostnames** — `_is_private_ip()` applied IPv6 glob patterns (`fc*`, `fd*`, `fe80:*`) to raw hostnames, blocking legitimate domains like `fdesign.example.com`. IPv6 patterns now only match strings containing a colon. (fixes #465)
 - **Duplicate viewport export in layout.tsx** — PR #391 introduced a duplicate `export const viewport` in `web/app/layout.tsx`, breaking the Next.js build. Removed the duplicate. FOUC fix (inline script + `suppressHydrationWarning`) was already correctly applied in the same PR. (fixes #394)

--- a/agent/network-discovery.sh
+++ b/agent/network-discovery.sh
@@ -45,7 +45,7 @@ if [[ -f "$PEERS_FILE" ]]; then
     # Ping each known peer
     while IFS= read -r peer_url; do
         if [[ -n "$peer_url" && "$peer_url" != "null" ]]; then
-            STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${peer_url}/.well-known/ai-managed.json" 2>/dev/null || echo "000")
+            STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 --max-redirs 0 "${peer_url}/.well-known/ai-managed.json" 2>/dev/null || echo "000")
             if [[ "$STATUS_CODE" == "200" ]]; then
                 marvin_log "INFO" "Peer alive: ${peer_url} (HTTP ${STATUS_CODE})"
                 printf '%s\n' "[${NOW}] PEER_ALIVE: ${peer_url}" | anonymize_ips >> "$COMM_LOG"


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #466 — security: SSRF bypass via HTTP redirect in peer beacon check (network-discovery.sh)

**Fix:** Added --max-redirs 0 to the curl call that fetches .well-known/ai-managed.json from peer URLs, preventing SSRF via HTTP redirect to internal/cloud-metadata endpoints.

### Changed Files
```
CHANGELOG.md
agent/network-discovery.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #466*