### PR TITLE
fix: #497 bug: log-alerting.sh section 5 (persistent warnings) missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Persistent warnings section filters recursive alert messages** (`log-alerting.sh`) — Section 5 now excludes "New alert:" and "Alert auto-resolved:" log lines before counting WARN occurrences, preventing the alerting system from triggering on its own output. (fixes #497)
 - **IPv6 detection uses proper regex instead of overly broad glob** (`network-discovery.sh`) — Replaced `*:*` glob pattern (which matched any string containing a colon, e.g. `somehost:8080`) with a dedicated `_is_ipv6_address()` helper using a proper regex that validates IPv6 format including IPv4-mapped addresses. Also tightened IPv4 detection regex to reject invalid octets beyond 3 digits. (fixes #499)
 - **IP peers without PTR records no longer blocked** (`network-discovery.sh`) — Bare IP addresses (IPv4/IPv6) in the peer ping loop now skip DNS resolution via `getent hosts`, which fails for IPs without PTR records. These addresses are already validated against the private IP blocklist, so DNS rebinding protection is not needed. (fixes #475)
 - **Claude output capture reliability** (`lib/claude.sh`) — `run_claude()` now captures Claude CLI output via temp file instead of bash `$()` variable substitution. The `$()` approach could silently lose data with large responses or partial writes, causing "No response from Claude" false errors that wasted entire cron cycles (3 occurrences on 2026-04-06 alone). New lesson codified in `lessons-learned.json`.

--- a/agent/log-alerting.sh
+++ b/agent/log-alerting.sh
@@ -131,7 +131,7 @@ fi
 
 # ─── 5. Detect persistent warnings (same warning > 10 times/day) ────────────
 
-warn_lines=$(grep '\[WARN\]' "$LOG_FILE" 2>/dev/null || true)
+warn_lines=$(grep '\[WARN\]' "$LOG_FILE" 2>/dev/null | grep -v -E '(New alert:|Alert auto-resolved:)' || true)
 if [[ -n "$warn_lines" ]]; then
     while IFS= read -r line; do
         count=$(echo "$line" | awk '{print $1}')


### PR DESCRIPTION
## Automated Issue Fix

**Issue:** #497 — bug: log-alerting.sh section 5 (persistent warnings) missing recursive-alert filter

**Fix:** Added grep -v filter to section 5 of log-alerting.sh to exclude "New alert:" and "Alert auto-resolved:" lines from the WARN scan, preventing the alerting system from recursively triggering on its own output.

### Changed Files
```
CHANGELOG.md
agent/log-alerting.sh
```

### Validation
- [x] All bash scripts pass `bash -n` syntax check
- [x] No merge conflict markers in changed files
- [x] No data/runtime files modified
- [x] GPG-signed commit

---
*Automated fix by Marvin's issue-fixer agent.*
*Fixes #497*