### PR TITLE
fix: #541 sync-and-learn writes empty report on Claude failure

### DIFF
--- a/agent/morning-check.sh
+++ b/agent/morning-check.sh
@@ -251,12 +251,10 @@ ${SYNC_CONTEXT}"
         SYNC_OUTPUT=$(run_claude "sync-and-learn" "$SYNC_FULL") || SYNC_EXIT=$?
         if [[ $SYNC_EXIT -ne 0 ]]; then
             marvin_log "WARN" "sync-and-learn Claude run failed (exit=${SYNC_EXIT}) — skipping learn report"
-            SYNC_OUTPUT=""
-        fi
-
-        # Save the learning report
-        LEARN_FILE="${DATA_DIR}/enhancements/${TODAY}-sync-learn-${TIMESTAMP}.md"
-        cat > "$LEARN_FILE" << EOF
+        else
+            # Save the learning report
+            LEARN_FILE="${DATA_DIR}/enhancements/${TODAY}-sync-learn-${TIMESTAMP}.md"
+            cat > "$LEARN_FILE" << EOF
 # Sync & Learn Report — ${NOW}
 
 ## Pull Summary
@@ -270,7 +268,8 @@ ${SYNC_OUTPUT}
 *Triggered by git pull at morning check*
 EOF
 
-        marvin_log "INFO" "Sync-and-learn report saved: ${LEARN_FILE}"
+            marvin_log "INFO" "Sync-and-learn report saved: ${LEARN_FILE}"
+        fi
     else
         marvin_log "WARN" "sync-learn.md prompt not found — skipping change analysis"
     fi


### PR DESCRIPTION
## Summary

Fixes #541.

When `run_claude "sync-and-learn"` fails, the code logged "skipping learn report" but still wrote a skeletal `LEARN_FILE` with an empty `SYNC_OUTPUT` section — cluttering `data/enhancements/` with useless files.

**Fix:** Wrap the learn file write in an `else` branch of the exit-code check, matching the pattern already used for the morning report section (added in PR #540).

## Changes

- `agent/morning-check.sh`: Move learn file write into the success branch. On failure, only the warning log is emitted — no file is created.

## Test plan

- [x] `bash -n agent/morning-check.sh` passes
- [ ] Next sync-and-learn failure produces only a log warning, no empty report file

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)