### PR TITLE
fix: remove break that aborts CPU monitoring loop (#547, #548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **`break` → fall-through in `find|git` CPU monitoring** (`health-monitor.sh`) — PR #546 replaced `continue` with `break` in the `find|git` case when `/proc/<pid>/exe` is unreadable, intending to fall through to runaway detection. However, `break` exits the entire `while` loop, silently dropping all remaining high-CPU processes from that scan cycle. Removed the `break` so the code falls through naturally: logs the "unverified" warning, then the "untrusted exe" warning, then continues to runaway detection. Fixes #547, #548.
+
 ### Added
 
 - **`git` added to runaway process exclusions** (`health-monitor.sh`) — Git operations (fetch, pull, push, rebase) spike to 100% CPU during morning-check and github-interact cron jobs. Like `find`, uses parent-process verification: only suppresses `git` from `/usr/bin/git` whose parent is a Marvin bash script. Non-Marvin git processes are still monitored and logged.

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -300,9 +300,11 @@ while IFS= read -r line; do
     proc_exe=$(readlink -f "/proc/${proc_pid}/exe" 2>/dev/null || echo "")
     case "$proc_name" in
         claude|apt*|dpkg*|ps|jq|fail2ban*|file|appstreamcli)
+            # High-frequency, low-risk short-lived children — silent skip when
+            # exe is unreadable (they exit between ps and readlink constantly).
+            # Contrast with find|git below which logs + falls through, because
+            # those run longer and an unreadable exe is more suspicious there.
             if [[ -z "$proc_exe" ]]; then
-                # Process exited between ps and readlink — can't verify, skip silently.
-                # Short-lived children (e.g., rkhunter's `file`) hit this constantly.
                 continue
             fi
             if [[ "$proc_exe" == /usr/bin/* || "$proc_exe" == /usr/sbin/* || \

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -323,7 +323,9 @@ while IFS= read -r line; do
                 # Fall through to normal runaway detection instead of skipping.
                 # An unreadable /proc/<pid>/exe could indicate namespace tricks,
                 # permission issues, or a race — silent exemption reduces coverage.
-                break
+                # NOTE: No break/continue here — proc_exe="" falls through to the
+                # _expected_exe check below (which fails), logging "Untrusted exe",
+                # then past esac into runaway detection. This is intentional (#547).
             fi
             _expected_exe="/usr/bin/${proc_name}"
             if [[ "$proc_exe" == "$_expected_exe" ]]; then


### PR DESCRIPTION
## Summary

- PR #546 replaced `continue` with `break` in the `find|git` case of the high-CPU process monitoring loop (line 326 of `health-monitor.sh`). The intent was to fall through to runaway detection when `/proc/<pid>/exe` is unreadable, but `break` exits the `while` loop entirely — silently dropping all remaining high-CPU processes from that scan cycle.
- Removed the `break`. The code now falls through naturally: logs the "unverified" warning, then hits the `_expected_exe` check (fails since `proc_exe` is empty), logs "Untrusted exe", and continues past `esac` into runaway detection.
- This is a security regression fix — a malware process named `find` that unlinks its binary after exec would reliably silence the monitor for the rest of the cycle.

Closes #547
Closes #548

## Test plan

- [ ] Verify `bash -n agent/health-monitor.sh` passes (done locally)
- [ ] Confirm the monitoring loop continues past processes with unreadable `/proc/<pid>/exe`
- [ ] Check that both WARN messages ("Cannot read exe" + "Untrusted exe") appear in logs for unverifiable processes