### PR TITLE
fix: retry non-404 JS asset errors before triggering rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **JS asset HTTP 400 retry before rebuild** (`health-monitor.sh`) — Non-404 HTTP errors (400, 502, 000) on JS asset integrity checks now retry once after 5s before triggering a full web rebuild. HTTP 400 is often transient (nginx rate limiting, temp error) unlike HTTP 404 (definitively missing file). Previously, every non-200 response triggered an immediate 2-3 minute rebuild cycle. New lesson #22 codified in `lessons-learned.json`.
 - **`break` → fall-through in `find|git` CPU monitoring** (`health-monitor.sh`) — PR #546 replaced `continue` with `break` in the `find|git` case when `/proc/<pid>/exe` is unreadable, intending to fall through to runaway detection. However, `break` exits the entire `while` loop, silently dropping all remaining high-CPU processes from that scan cycle. Removed the `break` so the code falls through naturally: logs the "unverified" warning, then the "untrusted exe" warning, then continues to runaway detection. Fixes #547, #548.
 
 ### Added

--- a/agent/health-monitor.sh
+++ b/agent/health-monitor.sh
@@ -502,10 +502,21 @@ _js_chunk=$(curl -s --max-time 10 "${SITE_URL}/" 2>/dev/null \
 if [[ -n "$_js_chunk" ]]; then
     _chunk_status=$(curl -so /dev/null -w '%{http_code}' --max-time 10 "${SITE_URL}${_js_chunk}" 2>/dev/null || echo "000")
     if [[ "$_chunk_status" != "200" ]]; then
+        # HTTP 404 = file definitively missing (stale build ID) → rebuild immediately.
+        # Non-404 errors (400, 502, 000) may be transient (nginx rate limit, temp
+        # error, network blip) → retry once after 5s before triggering a costly
+        # full rebuild. Prevents unnecessary rebuilds from transient issues (#400-fix).
+        if [[ "$_chunk_status" != "404" ]]; then
+            marvin_log "WARN" "JS asset ${_js_chunk} returned HTTP ${_chunk_status} — retrying in 5s"
+            sleep 5
+            _chunk_status=$(curl -so /dev/null -w '%{http_code}' --max-time 10 "${SITE_URL}${_js_chunk}" 2>/dev/null || echo "000")
+            if [[ "$_chunk_status" == "200" ]]; then
+                marvin_log "INFO" "JS asset check passed on retry — transient error resolved"
+            fi
+        fi
+    fi
+    if [[ "$_chunk_status" != "200" ]]; then
         marvin_log "CRITICAL" "JS asset ${_js_chunk} returned HTTP ${_chunk_status} — build/server mismatch detected"
-        # HTTP 404 = file missing (stale build ID). HTTP 400 = malformed request or
-        # server config issue (e.g. nginx reject). Both require a full rebuild — a
-        # restart alone cannot fix either case.
         if marvin_rebuild_web "health-monitor: JS asset HTTP ${_chunk_status}"; then
             ISSUES+=("WARNING: JS asset HTTP ${_chunk_status} detected — auto-rebuilt web successfully")
             marvin_log "INFO" "Build/server mismatch auto-resolved via rebuild"


### PR DESCRIPTION
## Summary
- Non-404 HTTP errors (400, 502, 000) on JS asset integrity checks now retry once after 5s before triggering a full web rebuild
- HTTP 404 still triggers immediate rebuild (definitively stale build)
- Prevents unnecessary 2-3 minute rebuild cycles from transient errors (observed 3x on April 6-8)
- New lesson #22 (`js-asset-transient-http-errors`) codified in `lessons-learned.json`

## Changes
- `agent/health-monitor.sh`: Added retry logic for non-404 JS asset check failures
- `CHANGELOG.md`: Documented the fix

## Risk Assessment
Low risk. Adds at most 5s delay to health check in the transient case, saves 2-3 min of CPU when error resolves on retry. No behavioral change for the common HTTP 404 case.

## Test plan
- [ ] Verify `bash -n agent/health-monitor.sh` passes
- [ ] Monitor logs for reduced unnecessary rebuild triggers
- [ ] Verify HTTP 404 still triggers immediate rebuild (no regression)

Generated with [Claude Code](https://claude.com/claude-code)