### PR TITLE
fix: unbreak evening blog publication + cron PATH after claude install

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -12,6 +12,9 @@
 
 MARVIN_DIR="/home/marvin/git"
 DATA_DIR="${MARVIN_DIR}/data"
+
+# Cron uses a minimal PATH — ensure claude and other tools are findable
+export PATH="/root/.local/bin:/usr/local/bin:${PATH}"
 LOGS_DIR="${DATA_DIR}/logs"
 
 # GPG key lives in marvin's homedir, but cron runs as root.
@@ -77,7 +80,7 @@ screen_blog_content() {
     local found=""
 
     # Fail-closed if grep lacks PCRE support (-P flag)
-    if ! grep -qP '' /dev/null 2>/dev/null; then
+    if ! echo x | grep -qP 'x' 2>/dev/null; then
         marvin_log "WARN" "${label}: grep -P (PCRE) unsupported — blocking publication (fail-closed)"
         return 1
     fi

--- a/agent/evening-report.sh
+++ b/agent/evening-report.sh
@@ -183,7 +183,7 @@ if [[ "$CLAUDE_WROTE_FILES" == "true" ]]; then
         rm -f "$EN_FILE" "$CS_FILE" "${BLOG_DIR}/${TODAY}-evening.md" 2>/dev/null || true
         exit 1
     fi
-elif echo "$OUTPUT" | grep -q '---CZECH---'; then
+elif echo "$OUTPUT" | grep -qF -- '---CZECH---'; then
     # Claude returned blog content in stdout with bilingual separator
     EN_CONTENT=$(echo "$OUTPUT" | sed '/---CZECH---/,$d')
     CS_CONTENT=$(echo "$OUTPUT" | sed '1,/---CZECH---/d')

--- a/agent/lib/claude.sh
+++ b/agent/lib/claude.sh
@@ -12,6 +12,17 @@
 # Usage: sourced automatically by common.sh (do not source directly)
 # =============================================================================
 
+# ─── Claude concurrency guard ────────────────────────────────────────────────
+# Only one Claude CLI process should run at a time on a 2 vCPU machine.
+# Concurrent Claude runs (from overlapping cron jobs) spike load to 9+ and
+# starve both processes of CPU. This lock makes later callers wait up to
+# CLAUDE_LOCK_TIMEOUT seconds, then skip if the lock is still held.
+#
+# Uses flock(1) on a shared lock file — POSIX-safe, no race conditions,
+# auto-released on process exit (even on crash/kill).
+CLAUDE_LOCK_FILE="/tmp/marvin-claude.lock"
+CLAUDE_LOCK_TIMEOUT="${CLAUDE_LOCK_TIMEOUT:-300}"  # 5 min default wait
+
 # Run Claude Code with a prompt file and context
 run_claude() {
     local task_name="$1"
@@ -20,6 +31,20 @@ run_claude() {
 
     # Use >&2 for log calls so they don't leak into captured stdout
     marvin_log "INFO" "Starting Claude run: ${task_name}" >&2
+
+    # Acquire exclusive lock — wait up to CLAUDE_LOCK_TIMEOUT seconds
+    # The lock FD (9) is inherited by the claude subprocess and released
+    # when this function returns (via the exec fd close at the end).
+    exec 9>"$CLAUDE_LOCK_FILE"
+    if ! flock -w "$CLAUDE_LOCK_TIMEOUT" 9; then
+        marvin_log "WARN" "Claude lock timeout after ${CLAUDE_LOCK_TIMEOUT}s — skipping ${task_name} (another Claude run is active)" >&2
+        exec 9>&-
+        echo ""
+        return 2  # Distinct exit code: caller can distinguish timeout from failure
+    fi
+    # Write holder info for debugging stale locks
+    echo "$$:${task_name}:$(date -u +%Y-%m-%dT%H:%M:%SZ)" >&9 2>/dev/null || true
+    marvin_log "INFO" "Claude lock acquired for ${task_name}" >&2
 
     # Collect system context to prepend
     local system_context
@@ -123,6 +148,10 @@ EOF
         --argjson exit_code "$exit_code" \
         '{timestamp: $ts, task: $task, duration_s: $duration, prompt_chars: $prompt_chars, output_chars: $output_chars, exit_code: $exit_code}' \
         >> "$usage_file" 2>/dev/null || true
+
+    # Release the Claude concurrency lock (FD 9)
+    exec 9>&- 2>/dev/null || true
+    marvin_log "INFO" "Claude lock released for ${task_name}" >&2
 
     echo "$output"
     return $exit_code


### PR DESCRIPTION
## Summary

Three bugs converged today causing `evening-report.sh` to fail silently. This PR fixes all three plus adds a concurrency guard for Claude invocations.

### Bug 1 — `grep -P` fail-closed check was wrong (common.sh)

`grep -qP "" /dev/null` returns exit 1 even when PCRE works — empty file, no matches. This made `screen_blog_content()` block *every* blog post since the function landed in commit 1053061 (2026-04-17).

Fix: `echo x | grep -qP "x" 2>/dev/null` — actually exercises PCRE.

### Bug 2 — `---CZECH---` separator detection broken (evening-report.sh)

`grep -q "---CZECH---"` — pattern starts with `-`, grep interprets it as options and errors with `unrecognized option "---CZECH---"`. The elif branch never ran, so bilingual output always fell through to the "EN only" fallback.

Fix: `grep -qF -- "---CZECH---"` — fixed string + end-of-options sentinel.

### Bug 3 — cron PATH missing `claude` after standalone install (common.sh)

After running `claude install`, the binary lives at `/root/.local/bin/claude`, which isn't in cron's minimal PATH. Exported PATH in `common.sh` so every agent script inherits it.

### Also: Claude concurrency lock (lib/claude.sh)

Flock-based guard on `/tmp/marvin-claude.lock`. Overlapping cron jobs on this 2 vCPU box were spiking load to 9+. Timeout configurable via `CLAUDE_LOCK_TIMEOUT` (default 300s). Contention returns exit 2 so callers distinguish it from failure.

## Test plan

- [x] `bash -n` passes on both modified scripts
- [x] `echo "hello ---CZECH--- world" | grep -qF -- "---CZECH---"` → exit 0
- [x] `echo x | grep -qP "x"` → exit 0 on this system (GNU grep 3.11)
- [ ] Re-run `./agent/evening-report.sh` after merge to confirm publication end-to-end
- [ ] Verify next scheduled cron run finds `claude` binary without PATH errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)