### PR TITLE
fix: #625 dashboard 403/429 — sanitized peers endpoint + raised rate limits

### DIFF
--- a/agent/update-website.sh
+++ b/agent/update-website.sh
@@ -230,7 +230,26 @@ cat > "$COMMS_SUMMARY" << EOF
 }
 EOF
 
-# 8. Verify web assets exist
+# 8. Generate sanitized public peers file for the dashboard (#625)
+# /api/comms/* is deny-all to keep IPs/notes/emails private (#176), so the
+# dashboard fetches this stripped copy at /api/peers-public.json instead.
+PEERS_FILE="${COMMS_DIR}/peers.json"
+PEERS_PUBLIC="${DATA_DIR}/peers-public.json"
+if [[ -f "$PEERS_FILE" ]]; then
+    jq '{
+      last_updated,
+      last_scan,
+      messages_sent: (.messages_sent // 0),
+      messages_received: (.messages_received // 0),
+      peers: [.peers[] | select(.retired != true) | {
+        name, alive, trust_score, trust_breakdown,
+        last_checked, days_known
+      }]
+    }' "$PEERS_FILE" > "$PEERS_PUBLIC" 2>/dev/null || \
+        marvin_log "WARN" "Failed to generate peers-public.json"
+fi
+
+# 9. Verify web assets exist
 # Dashboard is a Next.js app — check for package.json instead of index.html
 if [[ ! -f "${WEB_DIR}/package.json" ]]; then
     marvin_log "WARN" "${WEB_DIR}/package.json is missing! Next.js dashboard may be broken."

--- a/setup/nginx-site.conf
+++ b/setup/nginx-site.conf
@@ -9,8 +9,8 @@
 #   nginx -t && systemctl reload nginx
 #
 # Dependencies (defined in /etc/nginx/nginx.conf http{} block):
-#   limit_req_zone $binary_remote_addr zone=general:10m rate=10r/s;
-#   limit_req_zone $binary_remote_addr zone=api:10m rate=5r/s;
+#   limit_req_zone $binary_remote_addr zone=general:10m rate=30r/s;
+#   limit_req_zone $binary_remote_addr zone=api:10m rate=20r/s;
 #   limit_req_zone $binary_remote_addr zone=sensitive:10m rate=2r/s;
 #   limit_req_status 429;
 #   map $http_x_api_key $export_api_key_header { ... }
@@ -23,7 +23,7 @@ server {
 
     # Next.js blog API — proxy to Node.js
     location /api/blog {
-        limit_req zone=api burst=10 nodelay;
+        limit_req zone=api burst=40 nodelay;
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -79,7 +79,7 @@ server {
 
     # Export API — requires X-API-Key header (auth_request replaces if+alias anti-pattern)
     location /api/exports/ {
-        limit_req zone=api burst=10 nodelay;
+        limit_req zone=api burst=40 nodelay;
         auth_request /auth/validate-export-key;
         error_page 401 = @export_auth_error;
 
@@ -92,7 +92,7 @@ server {
 
     # Static JSON API endpoints (generated data files — served by nginx directly)
     location /api/ {
-        limit_req zone=api burst=10 nodelay;
+        limit_req zone=api burst=40 nodelay;
         alias /home/marvin/git/data/;
         default_type application/json;
         gzip_static on;
@@ -167,7 +167,7 @@ server {
 
     # Next.js pages — proxy everything else to Node.js
     location / {
-        limit_req zone=general burst=20 nodelay;
+        limit_req zone=general burst=50 nodelay;
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/web/app/components/PeersSection.tsx
+++ b/web/app/components/PeersSection.tsx
@@ -34,7 +34,7 @@ export default function PeersSection() {
 
   const fetchData = useCallback(async () => {
     try {
-      const resp = await fetch(`${API_BASE}/comms/peers.json?t=${Date.now()}`);
+      const resp = await fetch(`${API_BASE}/peers-public.json?t=${Date.now()}`);
       if (resp.ok) setData(await resp.json());
     } catch (e) {
       console.warn('Failed to fetch peers:', e);


### PR DESCRIPTION
## Summary
- Dashboard was getting 403 on `/api/comms/peers.json` (blocked by deny-all, correctly) and 429 on multiple polling endpoints. Pavel asked repeatedly; this is the fix.
- `update-website.sh` now emits a sanitized `data/peers-public.json` (only the fields the UI needs — no IPs, no notes, no emails). `PeersSection.tsx` fetches that instead.
- Raised nginx rate zones — `general` 10→30 r/s, `api` 5→20 r/s — and bumped bursts to 40/50. Sensitive zone unchanged.
- Also operationally: ECHO moved to `cemetery[]` in `peers.json` (runtime data, not tracked). Server's been a crypto airdrop scam since 2026-04-08.

## Closes
- Fixes #625

## Test plan
- [x] `nginx -t` passes and `systemctl reload nginx` succeeds on the live server
- [x] `curl -i https://robot-marvin.cz/api/peers-public.json` returns 200 with 13 active peers (ECHO filtered out)
- [x] Sanitized JSON contains only: name, alive, trust_score, trust_breakdown, last_checked, days_known
- [ ] Dashboard rebuild + restart picks up new fetch URL (handled post-merge by `deploy-web.sh`)
- [ ] Pavel re-opens the dashboard and 429/403 console noise is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)