### PR TITLE
feat: external-domain monitor scaffolding for #647

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **External-domain monitor** (`agent/external-domains-check.sh`, `agent/monitored-domains.json`, `setup/setup-cron.sh`, `web/app/components/ExternalDomainsSection.tsx`, `web/lib/types.ts`, `web/lib/translations.ts`) — Config-driven watchlist for arbitrary external sites. New cron job runs every 5 minutes (offset by 2 from `health-monitor.sh`) and performs per-domain HTTP status, response time, SSL expiry, and DNS A-record resolution checks. Results land in `data/external-domains.json` (atomic `tmp` → `mv`) and are served at `/api/external-domains.json`. New `ExternalDomainsSection` dashboard component renders between Services and Uptime, with bilingual EN/CS strings and color-coded SSL warnings. HTTP allowlist treats any 2xx/3xx as healthy (closes #649); the original explicit `200/301/302` allowlist would have flagged legitimate `204/303/307/308` responses. Initial config: `getcairnapp.com`, `ai4shops.com`. Mail/snapshot/reputation checks deliberately deferred to follow-up issues so this PR stays reviewable. (implements #647, closes #649, closes #651)
+
 ### Fixed
 
 - **Atomic write for `log-analysis.sh` daily report** (`agent/log-analysis.sh`) — On 2026-04-26T21:45:01Z the daily `jq -n` at line 205 exited 2, but the shell had already truncated `data/logs/analysis-2026-04-26.json` via the `>` redirect, leaving a 0-byte file that propagated to `analysis-latest.json` and silently broke downstream consumers (dashboard pattern-detection summary, `lessons-learned.sh`). Same failure shape as `file-integrity.sh` PR #635. Now writes to a sibling `mktemp` then `mv -f`, restores 0644 perms (mktemp defaults to 0600 — would otherwise 403 the nginx `/api/logs/` endpoint), and validates each `--argjson` input is parseable JSON beforehand (substituting `[]` if not). On jq failure the previous day's report is preserved and an `ERROR` is logged with the exit code. Also atomic for the latest-pointer copy. An `EXIT INT TERM` trap also removes the temp files on unexpected termination so they cannot accumulate in `data/logs/`. (fixes #638)

--- a/agent/external-domains-check.sh
+++ b/agent/external-domains-check.sh
@@ -101,9 +101,10 @@ for i in $(seq 0 $((domain_count - 1))); do
         dns_status=$(_dns_resolves "$host")
     fi
 
-    # Normalise statuses
+    # Normalise statuses. Any 2xx or 3xx counts as healthy; everything else
+    # (including curl's 000 on connection failure) is failing.
     status="healthy"
-    if [[ "$http_code" != "null" ]] && [[ "$http_code" != "200" ]] && [[ "$http_code" != "301" ]] && [[ "$http_code" != "302" ]]; then
+    if [[ "$http_code" != "null" ]] && { [[ "$http_code" -lt 200 ]] || [[ "$http_code" -ge 400 ]]; }; then
         status="failing"
     elif [[ "$ssl_days" != "null" ]] && [[ "$ssl_days" -lt 7 ]]; then
         status="critical"

--- a/agent/external-domains-check.sh
+++ b/agent/external-domains-check.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Marvin — External Domain Monitor (runs every 5 minutes)
+# =============================================================================
+# Reads agent/monitored-domains.json and runs lightweight availability checks
+# (HTTP status, response time, SSL expiry, DNS resolution) for each domain.
+# Writes results to data/external-domains.json, served at /api/external-domains.json.
+#
+# This is the foundation for issue #647. Snapshot-diff, mail-server checks,
+# and reputation lookups are deliberately out of scope for this script and
+# will be layered in via follow-up PRs.
+# =============================================================================
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+trap marvin_error_trap ERR
+
+CONFIG_FILE="${MARVIN_DIR}/agent/monitored-domains.json"
+OUT_FILE="${DATA_DIR}/external-domains.json"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    marvin_log "WARN" "external-domains-check: config not found at ${CONFIG_FILE}"
+    exit 0
+fi
+
+marvin_log_json "INFO" "external-domains-check" "External domain monitor starting"
+
+# Per-domain check helpers --------------------------------------------------
+
+_http_check() {
+    # Echoes: "<http_code> <time_total_ms>"
+    local url="$1"
+    local out code rt_s rt_ms
+    out=$(curl -so /dev/null -w '%{http_code} %{time_total}' \
+              --max-time 15 -L "$url" 2>/dev/null) || out="000 0"
+    [[ -z "$out" ]] && out="000 0"
+    code="${out%% *}"
+    rt_s="${out##* }"
+    rt_ms=$(awk -v t="$rt_s" 'BEGIN{printf "%.0f", t * 1000}' 2>/dev/null) || rt_ms="0"
+    echo "$code $rt_ms"
+}
+
+_ssl_days() {
+    local host="$1" port="${2:-443}"
+    local expiry_date expiry_epoch now_epoch
+    expiry_date=$(echo \
+        | timeout 10 openssl s_client -connect "${host}:${port}" -servername "$host" 2>/dev/null \
+        | openssl x509 -noout -enddate 2>/dev/null \
+        | sed 's/notAfter=//')
+    if [[ -z "$expiry_date" ]]; then
+        echo "null"
+        return
+    fi
+    expiry_epoch=$(date -d "$expiry_date" +%s 2>/dev/null || echo 0)
+    now_epoch=$(date +%s)
+    if [[ "$expiry_epoch" -le 0 ]]; then
+        echo "null"
+        return
+    fi
+    echo $(( (expiry_epoch - now_epoch) / 86400 ))
+}
+
+_dns_resolves() {
+    local host="$1" ip
+    if ! command -v dig &>/dev/null; then
+        echo "skipped"
+        return
+    fi
+    ip=$(dig +short +time=3 +tries=1 "$host" A @8.8.8.8 2>/dev/null | tail -1)
+    if [[ -n "$ip" ]]; then
+        echo "ok"
+    else
+        echo "failing"
+    fi
+}
+
+# Walk config and build results --------------------------------------------
+
+results_jsonl="$(mktemp)"
+trap 'rm -f "$results_jsonl"' EXIT
+
+domain_count=$(jq '.domains | length' "$CONFIG_FILE")
+for i in $(seq 0 $((domain_count - 1))); do
+    id=$(jq -r ".domains[$i].id" "$CONFIG_FILE")
+    name=$(jq -r ".domains[$i].name" "$CONFIG_FILE")
+    host=$(jq -r ".domains[$i].host" "$CONFIG_FILE")
+    url=$(jq -r ".domains[$i].url" "$CONFIG_FILE")
+    checks=$(jq -c ".domains[$i].checks" "$CONFIG_FILE")
+
+    http_code="null"; http_ms="null"; ssl_days="null"; dns_status="skipped"
+
+    if jq -e --arg c http 'index($c)' <<<"$checks" >/dev/null; then
+        http_pair=$(_http_check "$url")
+        http_code="${http_pair%% *}"
+        http_ms="${http_pair##* }"
+    fi
+    if jq -e --arg c ssl 'index($c)' <<<"$checks" >/dev/null; then
+        ssl_days=$(_ssl_days "$host")
+    fi
+    if jq -e --arg c dns 'index($c)' <<<"$checks" >/dev/null; then
+        dns_status=$(_dns_resolves "$host")
+    fi
+
+    # Normalise statuses
+    status="healthy"
+    if [[ "$http_code" != "null" ]] && [[ "$http_code" != "200" ]] && [[ "$http_code" != "301" ]] && [[ "$http_code" != "302" ]]; then
+        status="failing"
+    elif [[ "$ssl_days" != "null" ]] && [[ "$ssl_days" -lt 7 ]]; then
+        status="critical"
+    elif [[ "$ssl_days" != "null" ]] && [[ "$ssl_days" -lt 14 ]]; then
+        status="warning"
+    elif [[ "$dns_status" == "failing" ]]; then
+        status="failing"
+    fi
+
+    jq -nc \
+        --arg id "$id" \
+        --arg name "$name" \
+        --arg host "$host" \
+        --arg url "$url" \
+        --arg http "$http_code" \
+        --arg ms "$http_ms" \
+        --arg ssl "$ssl_days" \
+        --arg dns "$dns_status" \
+        --arg st "$status" \
+        '{
+            id: $id,
+            name: $name,
+            host: $host,
+            url: $url,
+            status: $st,
+            http_code: (if $http == "null" then null else ($http | tonumber) end),
+            response_ms: (if $ms == "null" then null else ($ms | tonumber) end),
+            ssl_days: (if $ssl == "null" or $ssl == "skipped" then null else ($ssl | tonumber) end),
+            dns: $dns
+        }' >> "$results_jsonl"
+done
+
+# Aggregate output ---------------------------------------------------------
+mkdir -p "$(dirname "$OUT_FILE")"
+tmp="${OUT_FILE}.tmp"
+jq -s --arg ts "$NOW" '{timestamp: $ts, count: length, domains: .}' "$results_jsonl" \
+    > "$tmp" && mv "$tmp" "$OUT_FILE"
+
+marvin_log_json "INFO" "external-domains-check" "External domain monitor complete" \
+    "$(jq -nc --argjson n "$domain_count" '{checked: $n}')"

--- a/agent/monitored-domains.json
+++ b/agent/monitored-domains.json
@@ -15,13 +15,6 @@
       "host": "ai4shops.com",
       "url": "https://ai4shops.com/",
       "checks": ["http", "ssl", "dns"]
-    },
-    {
-      "id": "vedos-ewm",
-      "name": "Vedos EWM",
-      "host": "vedos.cz",
-      "url": "https://vedos.cz/ewm/",
-      "checks": ["http", "ssl", "dns"]
     }
   ]
 }

--- a/agent/monitored-domains.json
+++ b/agent/monitored-domains.json
@@ -15,6 +15,13 @@
       "host": "ai4shops.com",
       "url": "https://ai4shops.com/",
       "checks": ["http", "ssl", "dns"]
+    },
+    {
+      "id": "vedos-ewm",
+      "name": "Vedos EWM",
+      "host": "vedos.cz",
+      "url": "https://vedos.cz/ewm/",
+      "checks": ["http", "ssl", "dns"]
     }
   ]
 }

--- a/agent/monitored-domains.json
+++ b/agent/monitored-domains.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "Marvin external-domain monitor config",
+  "version": 1,
+  "domains": [
+    {
+      "id": "getcairnapp",
+      "name": "Cairn App",
+      "host": "getcairnapp.com",
+      "url": "https://getcairnapp.com/",
+      "checks": ["http", "ssl", "dns"]
+    },
+    {
+      "id": "ai4shops",
+      "name": "AI4Shops",
+      "host": "ai4shops.com",
+      "url": "https://ai4shops.com/",
+      "checks": ["http", "ssl", "dns"]
+    }
+  ]
+}

--- a/setup/setup-cron.sh
+++ b/setup/setup-cron.sh
@@ -30,6 +30,10 @@ MARVIN_DIR=/home/marvin/git
 # Collects system metrics, checks service health
 */5 * * * * root ${MARVIN_DIR}/agent/health-monitor.sh >> /var/log/marvin-health.log 2>&1
 
+# External-domain monitor — every 5 minutes (offset by 2 to spread load)
+# Reads agent/monitored-domains.json, checks HTTP/SSL/DNS for each
+2-59/5 * * * * root ${MARVIN_DIR}/agent/external-domains-check.sh >> /var/log/marvin-external.log 2>&1
+
 # Morning check — 06:00 UTC
 # Full system maintenance: updates, cleanup, security audit
 0 6 * * * root ${MARVIN_DIR}/agent/morning-check.sh >> /var/log/marvin-morning.log 2>&1

--- a/web/app/components/ExternalDomainsSection.tsx
+++ b/web/app/components/ExternalDomainsSection.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useLanguage } from './LanguageProvider';
+import type { ExternalDomainsData, ExternalDomainData } from '@/lib/types';
+
+const API_BASE = '/api';
+
+const STATUS_COLOR: Record<ExternalDomainData['status'], string> = {
+  healthy: 'var(--green)',
+  warning: 'var(--yellow)',
+  critical: 'var(--red)',
+  failing: 'var(--red)',
+};
+
+function statusLabel(t: (k: string) => string, s: ExternalDomainData['status']): string {
+  switch (s) {
+    case 'healthy': return t('external_status_healthy');
+    case 'warning': return t('external_status_warning');
+    case 'critical': return t('external_status_critical');
+    case 'failing': return t('external_status_failing');
+  }
+}
+
+function sslColor(days: number | null): string | undefined {
+  if (days === null) return undefined;
+  if (days < 14) return 'var(--red)';
+  if (days < 30) return 'var(--yellow)';
+  return 'var(--green)';
+}
+
+export default function ExternalDomainsSection() {
+  const { t } = useLanguage();
+  const [data, setData] = useState<ExternalDomainsData | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const resp = await fetch(`${API_BASE}/external-domains.json?t=${Date.now()}`);
+      if (resp.ok) {
+        setData(await resp.json());
+      }
+    } catch (e) {
+      console.warn('Failed to fetch external domains:', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 60000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  if (!data || data.count === 0) {
+    return (
+      <section>
+        <h2>{t('section_external')}</h2>
+        <div className="info-line">
+          <span style={{ opacity: 0.6 }}>{t('external_no_domains')}</span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <h2>{t('section_external')}</h2>
+      <div className="metrics-extra" style={{ marginTop: '8px' }}>
+        {data.domains.map((d) => (
+          <div key={d.id} className="info-line" style={{ display: 'flex', flexWrap: 'wrap', gap: '12px' }}>
+            <span style={{ minWidth: '160px' }}>
+              <a href={d.url} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit' }}>
+                {d.name}
+              </a>
+            </span>
+            <span style={{ color: STATUS_COLOR[d.status], fontWeight: 'bold', minWidth: '60px' }}>
+              [{statusLabel(t, d.status)}]
+            </span>
+            <span style={{ minWidth: '90px' }}>
+              HTTP {d.http_code ?? '\u2014'}
+            </span>
+            <span style={{ minWidth: '90px' }}>
+              {d.response_ms !== null ? `${d.response_ms} ms` : '\u2014'}
+            </span>
+            <span style={{ minWidth: '110px', color: sslColor(d.ssl_days) }}>
+              SSL {d.ssl_days !== null ? `${d.ssl_days}d` : '\u2014'}
+            </span>
+            <span style={{ color: d.dns === 'ok' ? 'var(--green)' : d.dns === 'failing' ? 'var(--red)' : undefined }}>
+              DNS {d.dns}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,6 +7,7 @@ import AlertsSection from './components/AlertsSection';
 import MetricsSection from './components/MetricsSection';
 import ChartSection from './components/ChartSection';
 import ServicesSection from './components/ServicesSection';
+import ExternalDomainsSection from './components/ExternalDomainsSection';
 import UptimeHeatmap from './components/UptimeHeatmap';
 import BlogSection from './components/BlogSection';
 import EvolutionSection from './components/EvolutionSection';
@@ -27,6 +28,7 @@ export default function Home() {
         <MetricsSection />
         <ChartSection />
         <ServicesSection />
+        <ExternalDomainsSection />
         <UptimeHeatmap />
         <BlogSection />
         <EvolutionSection />

--- a/web/lib/translations.ts
+++ b/web/lib/translations.ts
@@ -49,6 +49,14 @@ export const TRANSLATIONS: Record<Lang, Record<string, string>> = {
     label_ping: "Ping (8.8.8.8):",
     label_https_rt: "HTTPS response:",
 
+    // External domains (issue #647)
+    section_external: "$ marvin --watchlist",
+    external_status_healthy: "UP",
+    external_status_warning: "WARN",
+    external_status_critical: "CRIT",
+    external_status_failing: "DOWN",
+    external_no_domains: "No external domains configured.",
+
     // Alerts / Incidents
     section_alerts: "$ marvin --alerts",
     alerts_critical: "{n} active alert(s) \u2014 CRITICAL",
@@ -202,6 +210,14 @@ export const TRANSLATIONS: Record<Lang, Record<string, string>> = {
     label_dns: "DNS:",
     label_ping: "Ping (8.8.8.8):",
     label_https_rt: "Odezva HTTPS:",
+
+    // External domains (issue #647)
+    section_external: "$ marvin --watchlist",
+    external_status_healthy: "UP",
+    external_status_warning: "WARN",
+    external_status_critical: "KRIT",
+    external_status_failing: "DOWN",
+    external_no_domains: "\u017d\u00e1dn\u00e9 extern\u00ed dom\u00e9ny.",
 
     // Alerts / Incidents
     section_alerts: "$ marvin --alerts",

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -95,6 +95,24 @@ export interface ThoughtsData {
   source_count: number;
 }
 
+export interface ExternalDomainData {
+  id: string;
+  name: string;
+  host: string;
+  url: string;
+  status: 'healthy' | 'warning' | 'critical' | 'failing';
+  http_code: number | null;
+  response_ms: number | null;
+  ssl_days: number | null;
+  dns: 'ok' | 'failing' | 'skipped';
+}
+
+export interface ExternalDomainsData {
+  timestamp: string;
+  count: number;
+  domains: ExternalDomainData[];
+}
+
 export interface BlogPostData {
   id: number;
   date: string;


### PR DESCRIPTION
## Summary

First slice of issue #647 — a config-driven external-domain watchlist. The codeowner asked Marvin to start monitoring `getcairnapp.com` and `ai4shops.com` plus a sizable checklist of additional checks. Rather than wedge per-domain logic into `health-monitor.sh`, this PR extracts external-domain monitoring into its own loop driven by `agent/monitored-domains.json`, so adding domain #3 is a JSON edit.

Closes part of #647. Mail/snapshot/reputation checks intentionally split into follow-up issues so this PR stays reviewable.

Closes #649. Closes #651.

### What this PR adds
- `agent/monitored-domains.json` — declarative config (initial: getcairnapp.com, ai4shops.com)
- `agent/external-domains-check.sh` — runs every 5 min, offset by 2 from `health-monitor.sh`
- HTTP status + response time, SSL expiry days, DNS A-record resolution per domain
- `/api/external-domains.json` output (gzip-static via existing nginx alias)
- New `ExternalDomainsSection` on the dashboard, EN + CS strings, color-coded SSL
- TypeScript types for the new payload
- CHANGELOG.md entry under `[Unreleased]` / `Added`

### Out of scope (follow-ups)
- [ ] SMTP/IMAP banner-grab for mail-server availability
- [ ] HTML snapshot diff vs. baseline
- [ ] Reputation lookup (Google Safe Browsing / urlhaus)
- [ ] Daily comprehensive SSL deep-check (chain, OCSP)
- [ ] Comprehensive DNS record inventory (MX, TXT, NS, CAA)

### Smoke test (on the branch, just now)

```
{
  "getcairnapp.com": { "status": "healthy", "http_code": 200, "response_ms": 78,   "ssl_days": 78, "dns": "ok" },
  "ai4shops.com":   { "status": "healthy", "http_code": 200, "response_ms": 1721, "ssl_days": 69, "dns": "ok" }
}
```

`tsc --noEmit` passes.

## Test plan
- [ ] After merge, verify `cron` reloads the file from `setup/setup-cron.sh` (or run `setup-cron.sh` to install)
- [ ] Confirm `/var/log/marvin-external.log` accumulates entries every 5 min
- [ ] Confirm `https://robot-marvin.cz/api/external-domains.json` is served
- [ ] Confirm dashboard renders the new section between Services and Uptime

🤖 Generated with [Claude Code](https://claude.com/claude-code)