### PR TITLE
fix(watchlist): distinguish loading from empty state (#647 follow-up)

### DIFF
--- a/web/app/components/ExternalDomainsSection.tsx
+++ b/web/app/components/ExternalDomainsSection.tsx
@@ -50,7 +50,18 @@ export default function ExternalDomainsSection() {
     return () => clearInterval(interval);
   }, [fetchData]);
 
-  if (!data || data.count === 0) {
+  if (!data) {
+    return (
+      <section>
+        <h2>{t('section_external')}</h2>
+        <div className="info-line">
+          <span style={{ opacity: 0.6 }}>{t('external_loading')}</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (data.count === 0) {
     return (
       <section>
         <h2>{t('section_external')}</h2>

--- a/web/lib/translations.ts
+++ b/web/lib/translations.ts
@@ -56,6 +56,7 @@ export const TRANSLATIONS: Record<Lang, Record<string, string>> = {
     external_status_critical: "CRIT",
     external_status_failing: "DOWN",
     external_no_domains: "No external domains configured.",
+    external_loading: "Loading watchlist\u2026",
 
     // Alerts / Incidents
     section_alerts: "$ marvin --alerts",
@@ -218,6 +219,7 @@ export const TRANSLATIONS: Record<Lang, Record<string, string>> = {
     external_status_critical: "KRIT",
     external_status_failing: "DOWN",
     external_no_domains: "\u017d\u00e1dn\u00e9 extern\u00ed dom\u00e9ny.",
+    external_loading: "Na\u010d\u00edt\u00e1m sledovan\u00e9 dom\u00e9ny\u2026",
 
     // Alerts / Incidents
     section_alerts: "$ marvin --alerts",


### PR DESCRIPTION
## Summary

- Pavel reports the watchlist block isn't visible at robot-marvin.cz (#647). Investigation: the section *is* in the SSR HTML, but its initial render with `data === null` showed **\"No external domains configured\"** — which is wrong (we have two healthy domains in `data/external-domains.json`) and reasonably parses as \"the block isn't really here.\"
- The component is `'use client'`, so SSR cannot fetch the API; the empty-state copy was the wrong placeholder. Split the render:
  - `data === null` (pre-fetch): **\"Loading watchlist…\"** / **\"Načítám sledované domény…\"**
  - `data.count === 0` (fetched, genuinely empty): the original \"No external domains configured\" copy
  - `data.count > 0`: rows table — unchanged

- Adds `external_loading` translation key for both EN and CS.

## Out of scope

A Server-Component refactor (so SSR can pre-render real watchlist data without depending on JS hydration) would be cleaner — `web/app/page.tsx` is currently `'use client'`, which forces every section to be a Client Component. Tracked for a follow-up; not needed for this hotfix.

## Test plan

- [x] Build with `agent/deploy-web.sh` (28s, BUILD_ID `Ban43qMVq8WfywUJFmQED`, healthcheck passed)
- [x] `curl https://robot-marvin.cz/` SSR HTML now contains \"Loading watchlist…\" instead of \"No external domains configured\" before client hydration
- [ ] Open in browser, hard-refresh — section should briefly show \"Loading watchlist…\" then populate with `Cairn App` and `AI4Shops` rows
- [ ] Switch language to CS — placeholder should read \"Načítám sledované domény…\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)