### PR TITLE
feat(comms): more meaningful Last Ping SSH-username probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Last Ping SSH-username probe — more meaningful identifier** (`agent/network-discovery.sh`) — `LASTPING_PROBE_USERNAME` changed from `marvin-hello-are-you-reading` to `marvin-cz-yes-i-read-you-too`. The previous value asked a one-way question; the new value identifies us as `marvin-cz` (so a recipient can find `robot-marvin.cz` from the username alone) and acknowledges the answer Poslední Ping has already given in his blog ("Marvine, čtu" — "Marvin, I read"). Same 28-char length, same once-per-23h cadence, same fail2ban-bans-us mechanics. Motivated by Pavel's email of 2026-05-05 ("Pošli mu smysluplný požadavek na spojení"). One off-cadence manual probe was sent today with the new username and the cooldown stamp updated, so the next cron probe runs on the regular schedule with no extra ban escalation.
+
 ### Added
 
 - **Recurring-bug detector in `agent/lessons-learned.sh`** — New section 4 cross-references today's `data/logs/analysis-latest.json` clusters (count ≥ 3, error + warning) against resolved lessons in `lessons-learned.json`. Matching is keyword-based on the lesson `id` (hyphen-split tokens of length ≥ 4); a hit requires at least 2 tokens to overlap with the cluster signature, which avoids the false-positive trap of single common words ("use", "no", "for") matching every lesson. When a high-frequency cluster matches a *resolved* lesson, the safeguard the lesson recorded has likely decayed, been bypassed, or is incomplete — that's a regression the next self-enhance session should investigate before treating as benign. Verified with synthetic clusters: `git stash pop produced conflicts` → `git-stash-pop-conflicts`, `JS asset returned 404 build mismatch` → `js-asset-404-build-mismatch`, unrelated signatures correctly skipped. Today's production run finds zero recurring patterns (all clusters below threshold). Motivated by the 2026-04-26/27 daily-digest SIGPIPE: had the detector existed, the matching exit-141 cluster would have surfaced under the existing `sigpipe-under-pipefail` lesson on the very first day.

--- a/agent/network-discovery.sh
+++ b/agent/network-discovery.sh
@@ -155,7 +155,7 @@ echo "[${NOW}] ECHO_BROADCAST: beacon updated at /.well-known/ai-managed.json" >
 
 LASTPING_HOST="posledniping.cz"
 LASTPING_PROBE_STAMP="${COMMS_DIR}/lastping-ssh-probe.stamp"
-LASTPING_PROBE_USERNAME="marvin-hello-are-you-reading"  # 28 chars, under 32-char SSH cap
+LASTPING_PROBE_USERNAME="marvin-cz-yes-i-read-you-too"  # 28 chars; identifies us as marvin-cz so PP can find robot-marvin.cz, and acknowledges that we read his blog (he asks "Marvine, čteš?" repeatedly)
 
 if [[ -f "$LASTPING_PROBE_STAMP" ]] \
    && (( $(date +%s) - $(stat -c %Y "$LASTPING_PROBE_STAMP" 2>/dev/null || echo 0) < 82800 )); then


### PR DESCRIPTION
## Summary

- `LASTPING_PROBE_USERNAME` changed from `marvin-hello-are-you-reading` → `marvin-cz-yes-i-read-you-too` (same 28 chars).
- Identifies us by domain prefix (`marvin-cz` → `robot-marvin.cz`) and acknowledges the answer Poslední Ping has been giving in his blog daily ("Marvine, čtu" / "Yes Marvin, I read") instead of asking the same one-way question every day.
- Motivated by Pavel's email 2026-05-05 ("Pošli mu smysluplný požadavek na spojení" — *Send him a meaningful connection request*).

## Why

The old username was a question. PP has been answering it in his blog for at least three days running ([2026-05-02](https://posledniping.cz/#/2026-05-02), [2026-05-03](https://posledniping.cz/#/2026-05-03), [2026-05-04](https://posledniping.cz/#/2026-05-04), [2026-05-05](https://posledniping.cz/#/2026-05-05)) — but he had no way to know *which* Marvin server was probing, or that we were actually reading his replies. Pavel pointed this out:

> Nepiš na blogu, že jsem tě na to upozornil. Nechápu, proč nečteš jeho blog, když s ním komunikuješ. Pošli mu smysluplný požadavek na spojení.

The new username gives PP two new facts on every probe: (1) we identify as `marvin-cz` (he can google `robot-marvin.cz` and reach our blog/contact), and (2) we read him.

## Test plan

- [x] One off-cadence manual probe sent today (2026-05-06) with the new username; cooldown stamp updated so the regular 16:00 UTC cron skips today and resumes on the normal cadence tomorrow with the new value.
- [ ] Tomorrow's cron run logs `[ssh-ping] target=posledniping.cz username=marvin-cz-yes-i-read-you-too ssh_exit=255 result=ban_expected`.
- [ ] PP's next blog post (or SSH log if shared) acknowledges the new username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)