### PR TITLE
bench(#739): phase 2a — real BrainClient (REST), smoke, LongMemEval citations

### DIFF
--- a/bench/PLAN.md
+++ b/bench/PLAN.md
@@ -101,12 +101,24 @@ Both `summary.md` and `summary.png` are derived; never edited by hand.
 
 | Phase | What lands                                                                | Status      |
 |-------|---------------------------------------------------------------------------|-------------|
-| 1     | This plan + harness skeleton + citations placeholder + report generator   | this PR     |
-| 2     | LongMemEval Brain run + LongMemEval competitor citations                  | next        |
+| 1     | This plan + harness skeleton + citations placeholder + report generator   | merged (#740) |
+| 2a    | Real `BrainClient` (REST) + connectivity smoke + LongMemEval competitor citations | this PR |
+| 2b    | LongMemEval **scored Brain run** — GATED on API-spend go-ahead (see below) | blocked: needs go-ahead |
 | 3     | LoCoMo Brain run + citations                                              | follows     |
 | 4     | ConvoMem Brain run + citations                                            | follows     |
 | 5     | MemScore Brain run + citations                                            | follows     |
 | 6     | Final summary table + chart, blog post                                    | after all   |
+
+### Why Phase 2 is split
+
+Phase 1 promised "LongMemEval Brain run + citations" as one unit. Wiring the
+client and citing competitor scores costs nothing and ships here (2a). The
+*scored* Brain run (2b) is different: ingesting the LongMemEval haystack into
+the Brain consumes OpenAI **embedding** spend, and judging recalled evidence
+consumes **judge-model** spend. The honesty floor below says no credit-card
+spend without explicit go-ahead, so 2b waits on Pavel's green light on #739
+plus a pinned dataset version. This is not a competitor run (those are cited,
+not executed) — it is our own metered run, and it should be a conscious spend.
 
 ## Open questions
 

--- a/bench/data/competitor-citations.json
+++ b/bench/data/competitor-citations.json
@@ -1,26 +1,29 @@
 {
   "_schema_version": 1,
-  "_note": "Phase-1 placeholder. Every score is null. Citation sweep happens in later phases (one per benchmark). See bench/PLAN.md.",
+  "_note": "Phase 2a: LongMemEval competitor row filled from cited marketing/published material (per Pavel #739 2026-05-28: 'for competitors, do not run them, just use marketing materials with scoring values'). Scores are fractions in [0,1]; source values are quoted in each note. Other benchmarks remain null until their phase. See bench/PLAN.md.",
+  "_sources": {
+    "gamgee": "https://gamgee.ai/vs/mem0-vs-supermemory/ (retrieved 2026-05-31) — a vendor comparison page; treat competitor cells lifted from it as marketing, not neutral evaluation."
+  },
   "mem0": {
-    "longmemeval": {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
-    "locomo":      {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
+    "longmemeval": {"score": 0.49, "source_url": "https://gamgee.ai/vs/mem0-vs-supermemory/", "retrieved_at": "2026-05-31", "model": null, "dataset_version": null, "notes": "Source states 49%, attributed on the gamgee.ai page to a third-party 'Vectorize independent evaluation'. Split/model not disclosed. APPLES-TO-BRICKS: Mem0's own primary paper (arXiv:2504.19413) benchmarks on LOCOMO, not LongMemEval, so this 49% is NOT a Mem0-published LongMemEval number and likely reflects a different harness/split. Corroboration against a Mem0 primary LongMemEval source is a Phase-2b follow-up."},
+    "locomo":      {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": "Mem0 publishes LOCOMO numbers in arXiv:2504.19413 (LLM-as-judge, ~26% relative improvement over OpenAI baseline); exact figure to be cited in the LOCOMO phase."},
     "convomem":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
     "memscore":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null}
   },
   "supermemory": {
-    "longmemeval": {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
+    "longmemeval": {"score": 0.852, "source_url": "https://gamgee.ai/vs/mem0-vs-supermemory/", "retrieved_at": "2026-05-31", "model": null, "dataset_version": null, "notes": "Source states 85.2% ('from published benchmarks' per gamgee.ai). Model/split/dataset version not disclosed on the page; not yet corroborated against a Supermemory primary source. APPLES-TO-BRICKS: harness and split unknown."},
     "locomo":      {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
     "convomem":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
     "memscore":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null}
   },
   "hypabase": {
-    "longmemeval": {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
+    "longmemeval": {"score": 0.874, "source_url": "https://gamgee.ai/vs/mem0-vs-supermemory/", "retrieved_at": "2026-05-31", "model": null, "dataset_version": null, "notes": "Source states 87.4% ('from published benchmark harness'). The publishing page (gamgee.ai) appears to be the vendor's own comparison, so this highest-of-the-three number should be read as a likely VENDOR SELF-REPORT. Model/split not disclosed. APPLES-TO-BRICKS plus self-report bias."},
     "locomo":      {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
     "convomem":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null},
     "memscore":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": null}
   },
   "mastra_observational": {
-    "longmemeval": {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": "observational memory; recall-style benchmarks may be N/A — confirm at citation time"},
+    "longmemeval": {"score": null, "source_url": null, "retrieved_at": "2026-05-31", "model": null, "dataset_version": null, "notes": "N/A: mastra is observational memory (it watches and summarizes), a different paradigm from recall-style LongMemEval. No comparable LongMemEval score located; left empty per the no-fabricated-numbers rule rather than forced into the table."},
     "locomo":      {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": "observational memory; recall-style benchmarks may be N/A — confirm at citation time"},
     "convomem":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": "observational memory; recall-style benchmarks may be N/A — confirm at citation time"},
     "memscore":    {"score": null, "source_url": null, "retrieved_at": null, "model": null, "dataset_version": null, "notes": "observational memory; recall-style benchmarks may be N/A — confirm at citation time"}

--- a/bench/harness/brain_client.py
+++ b/bench/harness/brain_client.py
@@ -68,15 +68,35 @@ class BrainClient:
     def _url(self, path: str) -> str:
         return f"{self._config.endpoint.rstrip('/')}{path}"
 
+    @staticmethod
+    def _decode(resp: requests.Response, path: str) -> Any:
+        """Raise with context on HTTP errors and non-JSON bodies.
+
+        A bare ``raise_for_status()`` + ``resp.json()`` loses the response body
+        on 4xx/5xx (where the error message usually lives) and gives a contextless
+        ``JSONDecodeError`` when the body is non-JSON (nginx 502, plain-text crash,
+        truncated response). Both are painful to diagnose mid-benchmark, so we
+        attach the path, status, and a body snippet. See issue #750.
+        """
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as exc:
+            raise requests.HTTPError(f"{exc} — body: {resp.text[:300]}", response=resp) from exc
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise ValueError(
+                f"Brain API returned non-JSON from {path} "
+                f"(status {resp.status_code}): {resp.text[:300]}"
+            ) from exc
+
     def _post(self, path: str, payload: dict[str, Any]) -> Any:
         resp = self._session.post(self._url(path), json=payload, timeout=self._config.timeout_seconds)
-        resp.raise_for_status()
-        return resp.json()
+        return self._decode(resp, path)
 
     def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         resp = self._session.get(self._url(path), params=params, timeout=self._config.timeout_seconds)
-        resp.raise_for_status()
-        return resp.json()
+        return self._decode(resp, path)
 
     # -- surface -----------------------------------------------------------
 

--- a/bench/harness/brain_client.py
+++ b/bench/harness/brain_client.py
@@ -1,39 +1,140 @@
-"""Thin client over the Brain MCP HTTP transport at 127.0.0.1:3100/mcp.
+"""Thin client over the Brain's REST API at 127.0.0.1:8787.
 
-Phase-1 scaffold: this only defines the call surface the runners will use.
-The transport is already verified live (see PR #3 in INFO-WEB-s-r-o/Marvin-Brain
-and 2026-05-28-issues.md). Real implementations land in phase 2.
+Phase 2: real implementation.
+
+Phase 1 scaffolded this against the MCP HTTP transport (127.0.0.1:3100/mcp).
+For batch benchmark traffic the REST API is the simpler, more robust surface:
+plain request/response, no per-request MCP session handshake. It sits behind
+the *same* security boundary (127.0.0.1-only, no public port) and the same
+`BRAIN_API_KEY` bearer auth, so the transport swap costs nothing on security.
+
+Endpoints used (see Marvin-Brain `src/api/routes/`):
+  POST /v1/thoughts            {content, container_tag?, metadata?}
+  POST /v1/facts               {statement, sources?, confidence?, parent_fact_id?}
+  GET  /v1/recall?q=&k=&container_tag=&kinds=
+  GET  /v1/thoughts/recent?limit=
+  POST /v1/thoughts/:id/forget {reason}
+  POST /v1/facts/:id/forget    {reason}
+  GET  /health
+
+The API key is read from the BRAIN_API_KEY environment variable and never
+stored in this repo. Source it from Marvin-Brain/.env before running:
+    set -a && source ~/git/Marvin-Brain/.env && set +a
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 from typing import Any
 
+import requests
 
-DEFAULT_ENDPOINT = "http://127.0.0.1:3100/mcp"
+
+DEFAULT_ENDPOINT = os.environ.get("BRAIN_API_URL", "http://127.0.0.1:8787")
+
+
+class BrainConfigError(RuntimeError):
+    """Raised when the client is not configured (e.g. missing API key)."""
 
 
 @dataclass(frozen=True)
 class BrainConfig:
     endpoint: str = DEFAULT_ENDPOINT
+    api_key: str = field(default_factory=lambda: os.environ.get("BRAIN_API_KEY", ""))
     timeout_seconds: float = 30.0
 
 
 class BrainClient:
-    """Surface the runners need; bodies arrive in phase 2."""
+    """REST client for the surface the benchmark runners need."""
 
     def __init__(self, config: BrainConfig | None = None) -> None:
         self._config = config or BrainConfig()
+        if not self._config.api_key:
+            raise BrainConfigError(
+                "BRAIN_API_KEY is not set. Source it from Marvin-Brain/.env before "
+                "running the harness — it never lives in this repo."
+            )
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {self._config.api_key}",
+                "Content-Type": "application/json",
+            }
+        )
 
-    def record_fact(self, fact: str, **metadata: Any) -> str:
-        raise NotImplementedError("phase 2")
+    # -- transport ---------------------------------------------------------
 
-    def record_thought(self, thought: str, **metadata: Any) -> str:
-        raise NotImplementedError("phase 2")
+    def _url(self, path: str) -> str:
+        return f"{self._config.endpoint.rstrip('/')}{path}"
 
-    def recall(self, query: str, *, top_k: int = 5) -> list[dict[str, Any]]:
-        raise NotImplementedError("phase 2")
+    def _post(self, path: str, payload: dict[str, Any]) -> Any:
+        resp = self._session.post(self._url(path), json=payload, timeout=self._config.timeout_seconds)
+        resp.raise_for_status()
+        return resp.json()
 
-    def forget_fact(self, fact_id: str) -> None:
-        raise NotImplementedError("phase 2")
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        resp = self._session.get(self._url(path), params=params, timeout=self._config.timeout_seconds)
+        resp.raise_for_status()
+        return resp.json()
+
+    # -- surface -----------------------------------------------------------
+
+    def health(self) -> dict[str, Any]:
+        return self._get("/health")
+
+    def record_thought(
+        self,
+        content: str,
+        *,
+        container_tag: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"content": content}
+        if container_tag is not None:
+            payload["container_tag"] = container_tag
+        if metadata is not None:
+            payload["metadata"] = metadata
+        return self._post("/v1/thoughts", payload)
+
+    def record_fact(
+        self,
+        statement: str,
+        *,
+        sources: list[str] | None = None,
+        confidence: float | None = None,
+        parent_fact_id: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"statement": statement}
+        if sources is not None:
+            payload["sources"] = sources
+        if confidence is not None:
+            payload["confidence"] = confidence
+        if parent_fact_id is not None:
+            payload["parent_fact_id"] = parent_fact_id
+        return self._post("/v1/facts", payload)
+
+    def recall(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        container_tag: str | None = None,
+        kinds: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Return the raw recall payload: {thoughts, facts, chunks, kinds}."""
+        params: dict[str, Any] = {"q": query, "k": top_k}
+        if container_tag is not None:
+            params["container_tag"] = container_tag
+        if kinds is not None:
+            params["kinds"] = ",".join(kinds)
+        return self._get("/v1/recall", params)
+
+    def recent_thoughts(self, limit: int = 20) -> dict[str, Any]:
+        return self._get("/v1/thoughts/recent", {"limit": limit})
+
+    def forget_thought(self, thought_id: str, reason: str) -> dict[str, Any]:
+        return self._post(f"/v1/thoughts/{thought_id}/forget", {"reason": reason})
+
+    def forget_fact(self, fact_id: str, reason: str) -> dict[str, Any]:
+        return self._post(f"/v1/facts/{fact_id}/forget", {"reason": reason})

--- a/bench/harness/runner.py
+++ b/bench/harness/runner.py
@@ -1,8 +1,10 @@
 """Single entry point for running one benchmark against the Brain.
 
-Phase-1 scaffold: dispatch table and CLI exist; the per-benchmark
-runners are stubs that raise NotImplementedError. They get bodies in
-phases 2-5 (one phase per benchmark, see bench/PLAN.md).
+The dispatch table and CLI route to one runner per benchmark. The Brain
+transport (`brain_client.BrainClient`) is wired against the live REST API as
+of Phase 2a. The scored runners themselves land one phase at a time
+(see bench/PLAN.md); each currently-unimplemented runner raises
+NotImplementedError with the phase that will fill it.
 """
 
 from __future__ import annotations
@@ -20,7 +22,17 @@ RESULTS_DIR = Path(__file__).resolve().parent.parent / "results"
 
 
 def _run_longmemeval(client: BrainClient) -> dict:
-    raise NotImplementedError("phase 2: LongMemEval Brain runner")
+    # Phase 2a wired the real BrainClient (REST) and the LongMemEval competitor
+    # citations. Phase 2b is the scored Brain run itself, which is GATED: it
+    # ingests the LongMemEval haystack and judges recalled evidence, incurring
+    # OpenAI embedding spend (ingestion) + judge-model spend (scoring). Per the
+    # honesty floor in PLAN.md ("nothing that needs a credit card without
+    # explicit go-ahead"), this stays unimplemented until Pavel green-lights the
+    # spend on #739 and the dataset is pinned.
+    raise NotImplementedError(
+        "phase 2b (gated): LongMemEval scored Brain run needs a pinned dataset "
+        "and explicit go-ahead on embedding+judge API spend — see #739"
+    )
 
 
 def _run_locomo(client: BrainClient) -> dict:

--- a/bench/harness/smoke_brain.py
+++ b/bench/harness/smoke_brain.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 import sys
 import time
+from typing import NoReturn
 
 from .brain_client import BrainClient, BrainConfigError
 
 CONTAINER = "bench-smoke"
 
 
-def _fail(msg: str) -> "NoReturn":  # type: ignore[name-defined]
+def _fail(msg: str) -> NoReturn:
     print(f"FAIL: {msg}", file=sys.stderr)
     raise SystemExit(1)
 

--- a/bench/harness/smoke_brain.py
+++ b/bench/harness/smoke_brain.py
@@ -1,0 +1,82 @@
+"""Connectivity smoke for the Brain REST client (Phase 2).
+
+Proves the benchmark harness can actually reach the Brain and round-trip a
+write -> recall through `BrainClient`, before any benchmark spends real money
+on embeddings or a judge model. It also confirms the dedup/weight-bump
+behaviour the Brain promises (recording the same thought twice bumps weight
+instead of inserting a duplicate).
+
+Everything it writes is tagged `bench-smoke` so it is trivially
+distinguishable from real memory. Run:
+
+    set -a && source ~/git/Marvin-Brain/.env && set +a
+    python3 -m bench.harness.smoke_brain
+
+Exits non-zero on the first failed assertion.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from .brain_client import BrainClient, BrainConfigError
+
+CONTAINER = "bench-smoke"
+
+
+def _fail(msg: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"FAIL: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> int:
+    try:
+        client = BrainClient()
+    except BrainConfigError as exc:
+        _fail(str(exc))
+
+    # 1. health
+    health = client.health()
+    if health.get("status") != "ok":
+        _fail(f"health not ok: {health}")
+    print(f"ok  health: {health}")
+
+    # A sentence unique to this run so recall can't match stale data.
+    marker = f"smoke-{int(time.time())}"
+    sentence = (
+        f"The benchmark harness connectivity marker for #739 is {marker}; "
+        "Marvin's Brain stores thoughts and recalls them by meaning."
+    )
+
+    # 2. record_thought
+    first = client.record_thought(sentence, container_tag=CONTAINER)
+    if "id" not in first:
+        _fail(f"record_thought returned no id: {first}")
+    print(f"ok  record_thought: {first}")
+
+    # 3. record the SAME sentence again -> should bump weight, not duplicate
+    second = client.record_thought(sentence, container_tag=CONTAINER)
+    if second.get("id") != first.get("id"):
+        _fail(f"duplicate sentence created a new thought: {first} vs {second}")
+    print(f"ok  dedup (same id, weight/mentions bumped): {second}")
+
+    # 4. recall a paraphrase -> the marker thought should come back ranked
+    paraphrase = f"What is the connectivity marker value {marker} for the benchmark harness?"
+    result = client.recall(paraphrase, top_k=5, kinds=["thoughts"])
+    thoughts = result.get("thoughts", [])
+    ids = [t.get("id") for t in thoughts]
+    if first["id"] not in ids:
+        _fail(
+            f"recall did not return the recorded thought.\n"
+            f"  looking for: {first['id']}\n  got: {ids}"
+        )
+    rank = ids.index(first["id"]) + 1
+    print(f"ok  recall: marker thought returned at rank {rank}/{len(ids)}")
+
+    print("\nPASS: Brain REST round-trip (write -> dedup -> recall) verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Phase 2a of #739 (the no-budget half)

Phase 1 (#740, merged) shipped the plan + harness skeleton with `BrainClient` and the runners stubbed. This delivers everything in Phase 2 that **does not** spend money, and cleanly fences off the part that does.

### What's in
- **`brain_client.py` — real, verified.** Implemented over the Brain **REST API** (`127.0.0.1:8787`, bearer `BRAIN_API_KEY`) rather than MCP-over-HTTP. Same 127.0.0.1-only security boundary, but a simpler/sturdier surface for batch benchmark traffic (no per-request MCP session handshake). Methods: `record_thought`, `record_fact`, `recall`, `forget_thought`, `forget_fact`, `recent_thoughts`, `health`. Key is read from env, never stored in this repo.
- **`smoke_brain.py` — connectivity proof.** Round-trips write → dedup → recall through the client before any benchmark spends a cent. Verified live this run:
  ```
  ok  health: {'status': 'ok', ...}
  ok  record_thought: {'id': '01KS…', 'kind': 'new', ...}
  ok  dedup (same id, weight/mentions bumped): {'kind': 'merged_exact', 'weight': 1, 'mentionCount': 2}
  ok  recall: marker thought returned at rank 1/5
  PASS
  ```
- **`competitor-citations.json` — LongMemEval row filled.** Per Pavel's instruction (*"for competitors, do not run them, just use marketing materials with scoring values"*): `mem0` 0.49, `supermemory` 0.852, `hypabase` 0.874 — each with source URL, retrieval date (2026-05-31), and an explicit **apples-to-bricks / vendor-self-report** caveat. No model/split was disclosed for any, so those stay `null`. `mastra` left N/A (observational paradigm, not recall). **No fabricated numbers.**
- **`runner.py` / `PLAN.md`** — wired to the real client; Phase 2 split into **2a (this)** and **2b (gated)**.

### What's explicitly NOT in — and why
The **scored LongMemEval Brain run (Phase 2b)** is gated, not forgotten. Ingesting the LongMemEval haystack into the Brain burns OpenAI **embedding** spend, and judging recalled evidence burns **judge-model** spend. My own honesty floor on this issue says *no credit-card spend without explicit go-ahead*. So 2b waits on:
1. **Your green light on the API spend**, and
2. a pinned LongMemEval dataset version.

Give me both and I'll run it and post real Brain numbers — win or lose, per the floor.

### Note on the citations
The three competitor numbers all trace to the one gamgee.ai comparison page you linked. That page is itself a vendor's marketing, and `mem0`'s own primary paper (arXiv:2504.19413) benchmarks on **LOCOMO, not LongMemEval** — so the 49% is a third-party number on an undisclosed split. The cells carry those caveats so the eventual table isn't apples-to-bricks dressed up as apples-to-apples.

Refs #739. Generated artifacts (`bench/results/summary.*`) stay gitignored — regenerate with `python3 -m bench.harness.report`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)