### PR TITLE
fix(github-interact): emit trailing NUL per block — dead ISSUE/COMMENT pipeline (#826)

### DIFF
--- a/agent/github-interact.sh
+++ b/agent/github-interact.sh
@@ -266,7 +266,7 @@ ${SIGNATURE}
         fi
     fi
 done < <(echo "$RESPONSE" | sed -n '/===ISSUE===/,/===END_ISSUE===/p' | \
-    awk '/===ISSUE===/{if(NR>1) printf "\0"; next} /===END_ISSUE===/{next} {print}')
+    awk '/===ISSUE===/{next} /===END_ISSUE===/{printf "\0"; next} {print}')
 
 # Parse COMMENT blocks
 # Format: ===COMMENT===\nissue: #number\nbody follows\n===END_COMMENT===
@@ -299,7 +299,7 @@ ${SIGNATURE}
         fi
     fi
 done < <(echo "$RESPONSE" | sed -n '/===COMMENT===/,/===END_COMMENT===/p' | \
-    awk '/===COMMENT===/{if(NR>1) printf "\0"; next} /===END_COMMENT===/{next} {print}')
+    awk '/===COMMENT===/{next} /===END_COMMENT===/{printf "\0"; next} {print}')
 
 # Parse CLOSE blocks
 # Format: ===CLOSE===\nissue: #number\nreason: ...\n===END_CLOSE===


### PR DESCRIPTION
Closes #826 (pending review — see the deliberate-merge note below).

## The bug

The block-splitting `awk` in the ISSUE and COMMENT parse loops emits `\0` as a
**separator**, not a **terminator**:

```awk
/===ISSUE===/{if(NR>1) printf "\0"; next} /===END_ISSUE===/{next} {print}
```

That prints N−1 NULs for N blocks. But the consumer reads NUL-**terminated**
records:

```bash
while IFS= read -r -d '' issue_block; do …
```

`read -d ''` needs a trailing NUL to deliver a record. With N−1 NULs the **last**
block is silently dropped — and in the overwhelmingly common single-block case
that is the *only* block, so **zero** actions fire. This is why
`github-interact.sh` logged `0 actions performed` across all 354 runs (#826),
exactly the finding parked in the #825 follow-up note.

## The fix

Emit the NUL at each `===END_*===` **terminator** instead, giving N NULs for N
blocks:

```awk
/===ISSUE===/{next} /===END_ISSUE===/{printf "\0"; next} {print}
```

Applied identically to both the ISSUE (line 265) and COMMENT (line 298) loops.

## Verification

Standalone repro against the exact pipeline:

| payload | OLD delivered | NEW delivered |
|---|---|---|
| single ISSUE block | **0** | 1 |
| two ISSUE blocks | 1 | 2 |

`bash -n` + `shellcheck -S warning` clean.

## ⚠️ Deliberate-merge note

This PR **switches on the dormant autonomous public-GitHub write path** — once
merged, Marvin's ISSUE/COMMENT/CLOSE actions will actually post to this repo. Per
the explicit note in #825, that is a decision for a human, not a fast-track. I am
opening the PR so the fix is ready; I am **not** merging it. A human should review
and merge deliberately.

Out of scope: the CLOSE loop (line 302+) reads line-by-line and pulls `reason:`
globally from the first block regardless of which issue is being closed — a
separate pre-existing quirk, not the NUL bug. Left untouched to keep this change
surgical; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)