### PR TITLE
fix(codeowners): valid pattern syntax + throttle PR/issue creation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,11 +8,16 @@
 
 # Yes, even the parts Marvin wrote. Especially those.
 
-- @pavelstancik
+# GitHub Actions bot / Marvin's own account are listed too, so Marvin can act
 
-# GitHub Actions bot — creates issues from Claude Code Review (PR reviews).
+# on issues the Claude Code Review action opens against a PR.
 
-# Marvin should be able to act on these.
+#
 
-- @RobotMarvin2026
-- @github-actions
+# NOTE: CODEOWNERS syntax is "<pattern> <owner>...", not a bullet list. A bare
+
+# "- @user" matches a literal file named "-", never a real path, so no PR
+
+# could ever satisfy required_code_owner_review (#935).
+
+* @pavelstancik @RobotMarvin2026 @github-actions

--- a/agent/self-enhance.sh
+++ b/agent/self-enhance.sh
@@ -14,11 +14,27 @@
 
 set -euo pipefail
 source "$(dirname "$0")/common.sh"
+source "$(dirname "$0")/lib/github.sh"
 trap marvin_error_trap ERR
 
 marvin_log "INFO" "=== SELF-ENHANCEMENT STARTING ==="
 
 check_claude || exit 1
+
+# ─── Skip if too many open PRs already (don't pile up) ───────────────────────
+# Mirrors fix-issues.sh's guard — self-enhance opens PRs the same as
+# fix-issues does, but had no equivalent brake (added 2026-07-31, #935/#937
+# fallout: PRs were accumulating faster than they could be reviewed/merged).
+if github_check_token 2>/dev/null; then
+    open_prs=$(github_list_prs 10 2>/dev/null) && _prs_fetch_ok=true || _prs_fetch_ok=false
+    if [[ "$_prs_fetch_ok" == "true" ]] && echo "$open_prs" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        open_pr_count=$(echo "$open_prs" | jq 'length' 2>/dev/null || echo "0")
+        if [[ "$open_pr_count" -ge 3 ]]; then
+            marvin_log "INFO" "Already ${open_pr_count} open PRs — skipping self-enhancement to avoid pile-up"
+            exit 0
+        fi
+    fi
+fi
 
 # ─── Pre-flight: detect divergence from origin/main since morning sync ───────
 # morning-check.sh pulled at 04:00 UTC. Self-enhance runs at 08:00 UTC. PRs that

--- a/setup/setup-cron.sh
+++ b/setup/setup-cron.sh
@@ -135,10 +135,12 @@ MARVIN_DIR=/home/marvin/git
 # No Claude API call — pure log analysis
 50 * * * * root ${MARVIN_DIR}/agent/log-alerting.sh >> /var/log/marvin-alerting.log 2>&1
 
-# Issue fixer — every 2 hours at :25 (even hours)
+# Issue fixer — every 6 hours at :25
 # Reads open GitHub issues, fixes ONE per run, creates validated PR, auto-merges
-# Staggered from github-interact (:05) and hourly-check (:35)
-25 0,2,4,8,12,14,16,18,20,22 * * * root ${MARVIN_DIR}/agent/fix-issues.sh >> /var/log/marvin-fix-issues.log 2>&1
+# Staggered from github-interact (:05) and hourly-check (:35). Cut from every
+# 2h to every 6h (2026-07-31) — PRs were piling up faster than the review/merge
+# gate could drain them (see CODEOWNERS fix, #935/#937).
+25 0,6,12,18 * * * root ${MARVIN_DIR}/agent/fix-issues.sh >> /var/log/marvin-fix-issues.log 2>&1
 
 # Incident reports — twice daily at 00:15 and 12:15 UTC
 # Detects, diagnoses, documents, and auto-resolves incidents
@@ -195,7 +197,7 @@ log "  15,45 * * * *     Negotiate handler (protocol proposals)"
 log "  5  */2 * * *      GitHub interaction (issues, PRs, push)"
 log "  35   * * * *      Hourly watch (log errors + codeowner issues)"
 log "  50   * * * *      Log-based alerting (error detection)"
-log "  25 0,2,4,8,12,14,16,18,20,22 * * *  Issue fixer (one issue/run)"
+log "  25 0,6,12,18 * * *  Issue fixer (one issue/run)"
 log "  15 0,12 * * *     Incident reports (detect/diagnose/resolve)"
 log ""
 log "NOTE: weekly-analytics.sh runs from root's personal crontab (Sun 11:30),"


### PR DESCRIPTION
## Summary

- `CODEOWNERS` used `- @user` (markdown bullet syntax) instead of valid `<pattern> <owner>` syntax. GitHub parsed the pattern as a literal file named `-`, which never matches a real path, so `required_code_owner_review` on `main`'s ruleset could never be satisfied by any PR (#935). Collapsed to a single `* @pavelstancik @RobotMarvin2026 @github-actions` rule.
- `fix-issues.sh` cron cadence cut from every 2h to every 6h (both `/etc/cron.d/marvin` and `setup/setup-cron.sh`, kept in sync for the §9d-style drift self-test).
- `self-enhance.sh` now carries the same "skip if >=3 open PRs" pile-up guard `fix-issues.sh` already had (it opens PRs the same way but had no brake).

Together these should let the current backlog (57 open issues / 33 open PRs, most stuck at `mergeable_state: blocked` per #935/#937) actually drain via normal review/merge instead of continuing to grow.

## Test plan

- [x] `bash -n` on `agent/self-enhance.sh` and `agent/fix-issues.sh`
- [x] Verified `setup/setup-cron.sh`'s cron heredoc still byte-matches the live `/etc/cron.d/marvin` (the drift self-test in `agent/self-test.sh`)
- [x] `sudo crontab -n` / cron syntax check on the live file passed
- [ ] Confirm a subsequent PR from `main` actually becomes mergeable once a codeowner approves, now that the pattern is valid

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)