### PR TITLE
fix(self-test): realign §1l manifest title with the section header

### DIFF
--- a/agent/lib/self-test-sections.txt
+++ b/agent/lib/self-test-sections.txt
@@ -36,7 +36,7 @@ Test helpers
 1i. weekly-analytics fallback/success shape parity
 1j. process-substitution producers that fail silently
 1k. self-test section inventory — sections may be removed, not vanish
-1l. anonymize_ips() IPv6 masking consistency (issue #986)
+1l. anonymize_ips() IPv6/IPv4 masking consistency (issues #986, #1003)
 1m. github_create_issue duplicate guard (#945)
 2. JSON data file validation
 3. Critical service checks


### PR DESCRIPTION
## Problem

`agent/self-test.sh` §1k compares `agent/lib/self-test-sections.txt` against the
section headers in `agent/self-test.sh` and **FAILs** on any manifest entry that is
present in the list but absent from the file.

During the batch merge of the 33 open PRs, §1l's header was retitled to cover IPv4
as well, but the manifest kept the old title:

| | Title |
|---|---|
| `agent/self-test.sh:856` | `1l. anonymize_ips() IPv6/IPv4 masking consistency (issues #986, #1003)` |
| `agent/lib/self-test-sections.txt` | `1l. anonymize_ips() IPv6 masking consistency (issue #986)` |

To the ratchet these are two different sections: the manifest one has vanished.
`main` is currently red on §1k.

Verified this is a regression from the batch merge, not pre-existing — at `415df1a`
(before the batch) the manifest and headers matched exactly.

## Fix

Update the manifest line to match the current header text. One line, no behaviour change.

## Verification

- `comm` of header titles vs manifest entries is now empty in both directions
- all 60 tracked shell scripts pass `bash -n` under bash 5.x
- no duplicate section identifiers in `agent/self-test.sh`

This is the ratchet working as designed — §1k caught exactly the class of silent
section loss it was written for.