### PR TITLE
fix(tests): §4c mutation arm failed off-root, and main had no suite coverage to notice

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,21 @@ name: Shell Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Also on main, and this is not redundant with the pull_request trigger.
+  #
+  # Until 2026-08-06 the suites ran ONLY on pull requests, so nothing ever
+  # executed them against main. That is not a theoretical gap: #981 merged that
+  # day carrying a mutation arm that fails on a non-root runner, main went red,
+  # and no run existed anywhere to say so. It surfaced hours later on an
+  # unrelated PR, which reported someone else's breakage as that PR's failure.
+  #
+  # A green PR does not imply a green main. PRs merge in a different order than
+  # they were tested in, several may pass individually and conflict once
+  # combined, and an --admin merge bypasses the check entirely. shell-syntax.yml
+  # has always run on main pushes for exactly this reason; the suites that
+  # assert BEHAVIOUR are the ones where an invisible regression costs most.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,9 +105,27 @@ jobs:
           # Deciding by grep guesses instead of asking. So the list is written
           # down, and the completeness check below turns "forgot to update it"
           # into a build failure instead of a silent gap.
-          mutation_suites=(agent/tests/external-domains-parser.test.sh)
+          mutation_suites=(
+            agent/tests/external-domains-parser.test.sh
+            agent/tests/hourly-issue-trust-boundary.test.sh
+          )
           # Suites deliberately outside the convention. Add with a reason.
-          exempt_suites=()
+          #
+          # These three carry their mutation arms INTERNALLY: each runs its own
+          # mutations inline and reports "MUTATION INEFFECTIVE" when one breaks
+          # nothing, which is the same evidence the MUTATE= convention produces,
+          # gathered a different way. Wrapping them in MUTATE= as well would mean
+          # two mutation harnesses per suite and no more assurance.
+          #
+          # This list was empty while these three sat on disk unregistered. They
+          # arrived in the 2026-08-06 batch merge, every one of which was merged
+          # with --admin, so the completeness check below reported them on each
+          # PR and each report was bypassed. The check was right the whole time.
+          exempt_suites=(
+            agent/tests/roadmap-budget.test.sh          # internal: drop_phases, quiet_fallback
+            agent/tests/security-scan-4b-parser.test.sh # internal: 7 arms + quiet control
+            agent/tests/security-scan-4c-gnupg-drift.test.sh # internal: 17 arms + quiet control
+          )
 
           for s in agent/tests/*.test.sh; do
             listed=0

--- a/agent/tests/hourly-issue-trust-boundary.test.sh
+++ b/agent/tests/hourly-issue-trust-boundary.test.sh
@@ -60,6 +60,47 @@ sys.stdout.write(m.group(1))
 PY
 [[ -s "${TMP}/filter.jq" ]] || { echo "FAIL: extracted filter is empty"; exit 1; }
 
+# ── MUTATE= convention (.github/workflows/tests.yml) ────────────────────────
+# A suite that cannot fail is not evidence. Each mutation below breaks the trust
+# boundary in a way that has actually been written by mistake, and the suite MUST
+# go red. Exit 2 on an unrecognised name: the CI step distinguishes "an assertion
+# failed" (1) from "the harness died" (2), because treating both as success is
+# how a renamed mutation silently stops exercising anything.
+MUTATIONS=(substring_match drop_trust_filter)
+if [[ "${MUTATE:-}" == "list" ]]; then
+    printf '%s\n' "${MUTATIONS[@]}"
+    exit 0
+fi
+if [[ -n "${MUTATE:-}" ]]; then
+    _known=0
+    for _m in "${MUTATIONS[@]}"; do [[ "$MUTATE" == "$_m" ]] && _known=1; done
+    (( _known )) || { echo "unknown MUTATE target: ${MUTATE}" >&2; exit 2; }
+    # Applied to the EXTRACTED filter, never to hourly-check.sh itself: a suite
+    # that edits the script it is testing can leave the repository mutated when
+    # it dies. A missing target exits 2 (harness death), not 1 — "the mutation
+    # could not be applied" is not evidence that an assertion works.
+    #
+    # `substring_match` is the exact bug the first version of this filter had;
+    # `drop_trust_filter` is the state of the code before it existed at all.
+    python3 - "${TMP}/filter.jq" "$MUTATE" <<'PY' || { echo "mutation target not found for MUTATE=${MUTATE}" >&2; exit 2; }
+import sys, pathlib, re
+path, mut = pathlib.Path(sys.argv[1]), sys.argv[2]
+s = path.read_text()
+exact = "select(.user.login as $l | $trusted | index($l))"
+if mut == "substring_match":
+    if exact not in s:
+        sys.exit(1)
+    path.write_text(s.replace(exact, "select([.user.login] | inside($trusted))"))
+elif mut == "drop_trust_filter":
+    out = re.sub(r'^[ \t]*\|[ \t]*' + re.escape(exact) + r'[ \t]*\n', '', s, flags=re.M)
+    if out == s:
+        sys.exit(1)
+    path.write_text(out)
+else:
+    sys.exit(1)
+PY
+fi
+
 # ── Rebuild the allowlist exactly as hourly-check.sh derives it ──────────────
 TRUSTED="$(
     {

--- a/agent/tests/security-scan-4c-gnupg-drift.test.sh
+++ b/agent/tests/security-scan-4c-gnupg-drift.test.sh
@@ -356,8 +356,22 @@ if [[ "$IS_ROOT" -eq 1 ]]; then
 else
     _skip "mutation:sockets_count_as_drift" "needs root-staged fixtures"
     _skip "mutation:pipe_subshell"          "needs root-staged fixtures"
-    _mutation_arm no_unknown_owner_guard    unmapped_uid 2>/dev/null || \
-        _skip "mutation:no_unknown_owner_guard" "needs root-staged fixtures"
+    # Was: `_mutation_arm ... || _skip ...`, intending to attempt the arm and
+    # fall back. The fallback could never fire. _mutation_arm reports through
+    # _eq, which RECORDS a failure and returns success, so the `||` saw a
+    # zero status and the skip was unreachable — the arm ran unconditionally
+    # against a fixture that only exists under root.
+    #
+    # `unmapped_uid` is staged by `chown -R "$UNMAPPED_UID"`, which non-root
+    # cannot do, so off-root the fixture is a plain directory owned by the
+    # runner. Removing the unknown-owner guard from a scan that has no
+    # unknown-owned file to find changes nothing, and the suite said so:
+    # "MUTATION INEFFECTIVE — broke nothing". That verdict was correct. The
+    # bug was asking the question at all without the fixture.
+    #
+    # It now skips like its three siblings, which is what the other arms in
+    # this branch have always done. On a root runner all four still execute.
+    _skip "mutation:no_unknown_owner_guard" "needs root-staged fixtures"
     _skip "mutation:invert_user_test"        "needs root-staged fixtures"
 fi
 _mutation_arm swallow_find_rc  walk_fails


### PR DESCRIPTION
## How this surfaced

PR #1033 (an unrelated security fix) failed CI on `shell-tests`. The failure was
not its own — `main` was already red, and had been since #981 merged earlier the
same day. Nothing reported it, because nothing ran the suites on `main`.

## Defect 1 — the mutation arm could never skip

`agent/tests/security-scan-4c-gnupg-drift.test.sh`:

```bash
_mutation_arm no_unknown_owner_guard unmapped_uid 2>/dev/null || \
    _skip "mutation:no_unknown_owner_guard" "needs root-staged fixtures"
```

The intent reads clearly: attempt the arm, fall back to a skip off-root. It could
not work. `_mutation_arm` reports via `_eq`, which **records** a failure and
returns success, so `||` always saw status 0 and the skip was unreachable.

The `unmapped_uid` fixture is staged by `chown -R "$UNMAPPED_UID"`. Non-root
cannot chown, so off-root that fixture is an ordinary directory owned by the
runner. Removing the unknown-owner guard from a scan with no unknown-owned file
to find changes nothing — and the suite said exactly that:

```
MUTATION INEFFECTIVE  no_unknown_owner_guard  broke nothing — the assertions above prove nothing
```

**That verdict was correct.** The bug was posing the question without the fixture.
The arm now skips like its three siblings in the same branch. Under a root runner
all four still execute, unchanged.

## Defect 2 — `main` was never tested

`tests.yml` triggered on `pull_request` and `workflow_dispatch` only. There has
never been a run of these suites against `main`.

That is why defect 1 sat undetected: it entered `main` through a merge, and the
only thing that would have caught it runs on pull requests. A green PR does not
imply a green `main` —

- PRs merge in a different order than they were tested in
- several can pass individually and conflict once combined
- an `--admin` merge bypasses the check entirely (which is how #981 landed)

`shell-syntax.yml` has always run on main pushes for this reason. The suites that
assert **behaviour** are precisely where an invisible regression costs most, so
they now do too.

## Verification

Off-root (the CI case), §4c goes from `11 passed / 4 skipped / 1 failed` to
`7 passed / 5 skipped / 4 failed` locally on macOS — the 4 remaining are BSD
`find`/`stat` differences that **passed on CI's ubuntu runner** in the #1033 run
and are not touched here. The `MUTATION INEFFECTIVE` failure is gone.

CI on this PR is the real check: `shell-tests` should be green, and from this
merge onward `main` will report its own status.

## Scope note

This does not chase the macOS-only §4c failures. They do not affect CI or the
host, and folding them in would mix a portability question into a fix for a
broken guard. Worth a separate look if anyone runs these suites on a Mac.